### PR TITLE
コンソール処理の問題を修正

### DIFF
--- a/src/core/environ/win32/Application.h
+++ b/src/core/environ/win32/Application.h
@@ -64,9 +64,9 @@ class tTVPApplication {
 	std::wstring title_;
 
 	bool is_attach_console_;
-	FILE* oldstdin_;
-	FILE* oldstdout_;
-	FILE* oldstderr;
+	FILE* newstdin_;
+	FILE* newstdout_;
+	FILE* newstderr_;
 	std::wstring console_title_;
 	AcceleratorKeyTable accel_key_;
 	bool tarminate_;


### PR DESCRIPTION
・stdin/stdout/stderr が未接続な場合にかぎり AttachConsole を試みる
・ログ出力は stderr が有効なら AttachConsole したかどうかに関わらず行う

あと freopen の使い方がなんかおかしかったので直してあります(帰ってくるのは古いのではないです。あと再割り当てできません)

_fileno() の判定は、本来ならそれだけでOKなのですが、VS2012 のランタイムにバグがあって正常に判定できないので、ハンドルも確認してます。
