### PR TITLE
Visual Studio 2013 でビルドできるように変更

### DIFF
--- a/src/core/utils/win32/ThreadImpl.cpp
+++ b/src/core/utils/win32/ThreadImpl.cpp
@@ -12,6 +12,9 @@
 #include "tjsCommHead.h"
 
 #include <process.h>
+#if (_MSC_VER==1800)
+	#include <algorithm>
+#endif
 
 #include "ThreadIntf.h"
 #include "ThreadImpl.h"

--- a/src/core/visual/win32/BasicDrawDevice.cpp
+++ b/src/core/visual/win32/BasicDrawDevice.cpp
@@ -15,6 +15,9 @@
 
 #include <d3d9.h>
 #include <mmsystem.h>
+#if (_MSC_VER==1800)
+	#include <algorithm>
+#endif
 
 //---------------------------------------------------------------------------
 // ƒIƒvƒVƒ‡ƒ“


### PR DESCRIPTION
std::min, std::max が使えるようにalgorithmをinclude
