### PR TITLE
セパレートライン("-")の　MenuItem の caption プロパティの値が空文字になる問題の修正

### DIFF
--- a/src/plugins/win32/menu/WindowMenu.cpp
+++ b/src/plugins/win32/menu/WindowMenu.cpp
@@ -218,6 +218,13 @@ void WindowMenuItem::SetCaption( const TCHAR* caption ) {
 	UpdateMenu(false);
 }
 
+const TCHAR* WindowMenuItem::GetCaption() const {
+	if ( (menu_item_info_.fType & MFT_SEPARATOR) != 0 ) {
+		return _T("-");
+	}
+	return menu_item_info_.dwTypeData;
+}
+
 void WindowMenuItem::SetChecked( bool b ) {
 	if( GetRadioItem() ) {
 		if( b && parent_ ) {

--- a/src/plugins/win32/menu/WindowMenu.h
+++ b/src/plugins/win32/menu/WindowMenu.h
@@ -69,7 +69,7 @@ public:
 	void Delete( int index );
 
 	void SetCaption( const TCHAR* caption );
-	const TCHAR* GetCaption() const { return menu_item_info_.dwTypeData; }
+	const TCHAR* GetCaption() const;
 
 	HMENU GetHandle() { return hMenu_; }
 	int IndexOf( const WindowMenuItem* item );


### PR DESCRIPTION
new MenuItem(window, "-");
で作成したセパレートラインのMenuItemオブジェクトのcaptionプロパティが"-"になっていない問題を修正
