### PR TITLE
MenuItem.shortcutのテキスト→キーコード変換処理の改訂

### DIFF
--- a/src/plugins/win32/menu/readme.txt
+++ b/src/plugins/win32/menu/readme.txt
@@ -1,4 +1,18 @@
-ショートカットに指定可能な文字一覧(ショートカットとして機能するかは別問題、そちらは未確認)
+●使い方
+
+吉里吉里Ｚでメニュー(MenuItem, Window.menu)を拡張します。
+下記のようにしてWindowインスタンス作成前に本プラグインをリンクしてください。
+
+@if (kirikiriz)
+Plugins.link("menu.dll");
+@endif
+
+リンク後の基本的なメニューの機能は吉里吉里２と同様です。
+
+
+●ショートカットに指定可能な文字一覧
+※ショートカットとして機能するかは別問題で、そちらは未確認のため注意
+
 Backspace
 Tab
 Num 5
@@ -10,17 +24,17 @@ Esc
 変換
 無変換
 Space
-Num 9
-Num 3
-Num 1
-Num 7
-Num 4
-Num 8
-Num 6
-Num 2
+Page Up
+Page Down
+End
+Home
+Left
+Up
+Right
+Down
 Sys Req
-Num 0
-Num Del
+Insert
+Delete
 0
 1
 2
@@ -116,3 +130,39 @@ F
 Caps Lock
 ひらがな
 半角/全角
+
+
+●吉里吉里２との互換性について
+
+・フルスクリーンでメニューバーの自動消去／表示機能がありません
+＞TJS側で予め消去するなどの対応を行ってください
+
+・下記ショートカット向けプロパティが拡張されます
+
+global.MenuItem.textToKeycode = %[ ... ];
+global.MenuItem.keycodeToText =  [ ... ];
+
+MenuItem.shortcutのショートカットキーの文字列の変換テーブルです。
+仮想キーコードとテキストの相互変換に使用されます。
+（辞書の方はキーを全部小文字にして使用してください）
+
+textToKeycode[text.toLowerCase()] = VK_*;
+keycodeToText[VK_*] = text;
+
+詳細はプラグインリンク後の上記辞書／配列の中身を確認してください。
+中身を書き換えることができますが、MenuItem生成後での変更は行わないでください。
+
+吉里吉里２互換用に予め下記が追加されています。
+textToKeycode["BkSp".toLowerCase()] = VK_BACK;
+textToKeycode["PgUp".toLowerCase()] = VK_PRIOR;
+textToKeycode["PgDn".toLowerCase()] = VK_NEXT;
+
+・上記変換テーブルの仕様により、MenuItem.shortcutの表記が変わる場合があります
+（文字列⇒仮想キーコードが多対１のため、設定後は正規化されます）
+
+	var item = new MenuItem(window, "shortcut normalize test");
+	item.shortcut = "Shift+BkSp";
+	Debug.message(item.shortcut);
+	// -> Shift+Backspace
+
+


### PR DESCRIPTION
プラグインリンク時に予めテキスト→キーコードの辞書とキーコード→テキストの配列を生成しておき，
ショートカットプロパティ変更時に参照するようにしました。

合わせて下記の修正・調整を行っています。
・shortcut文字列の ignore case 対応（shift+ctrl+alt+a 等でも正しく機能するよう調整）
・操作系のキーコード文字列変換が正しくなかったので修正（Num ～となってNumPadと重複していた）
・変換テーブルを参照する static プロパティ MenuItem.textToKeycode, MenuItem.keycodeToText の追加
・readme.txtへの簡易説明記入
