### PR TITLE
MenuItem.onClick のイベント配信優先順位変更（ #123 より）

### DIFF
--- a/src/plugins/win32/menu/MenuItemIntf.cpp
+++ b/src/plugins/win32/menu/MenuItemIntf.cpp
@@ -329,7 +329,7 @@ void tTJSNI_MenuItem::OnClick(void)
 
 	// fire event
 	static ttstr eventname(TJS_W("onClick"));
-	TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
+	TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_NORMAL, 0, NULL);
 }
 //---------------------------------------------------------------------------
 tTJSNI_MenuItem * tTJSNI_MenuItem::GetRootMenuItem() const


### PR DESCRIPTION
TVP_EPT_IMMEDIATEからTVP_EPT_NORMALへ変更しました。
詳細は#123参照
