### PR TITLE
Window.menu.visible の更新処理を修正

### DIFF
--- a/src/plugins/win32/menu/MenuItemIntf.cpp
+++ b/src/plugins/win32/menu/MenuItemIntf.cpp
@@ -497,12 +497,24 @@ void tTJSNI_MenuItem::SetVisible(bool b)
 {
 	if(!MenuItem) return;
 	if(OwnerWindow) {
-		if( !b ) {
-			::SetMenu( HWnd, NULL );
+		bool update = false;
+		if( GetVisible() ) {
+			if( !b ) {
+				::SetMenu( HWnd, NULL );
+				update = true;
+			}
 		} else {
-			::SetMenu( HWnd, GetRootMenuItem()->GetMenuItemHandleForPlugin() );
+			if( b ) {
+				::SetMenu( HWnd, GetRootMenuItem()->GetMenuItemHandleForPlugin() );
+				update = true;
+			}
 		}
-		// Window->SetMenuBarVisible(b); 
+		// Window->SetMenuBarVisible(b);
+
+		// redraw window
+		if( update ) {
+			::RedrawWindow( HWnd, NULL, NULL, RDW_NOERASE | RDW_INVALIDATE | RDW_UPDATENOW );
+		}
 	} else {
 		MenuItem->SetVisible( b );
 	}


### PR DESCRIPTION
ルートメニューのvisible変更時の処理について下記を修正しました
・状態が変わらない場合は何もしない
・変更があった場合はメイン画面の再描画処理を発行する
＞visible=trueにした場合にゲーム画面に重なって表示されることがあったため
