### PR TITLE
TVPWindowのウィンドウスタイルの調整

### DIFF
--- a/src/core/environ/win32/TVPWindow.cpp
+++ b/src/core/environ/win32/TVPWindow.cpp
@@ -386,7 +386,12 @@ HRESULT tTVPWindow::CreateWnd( const std::wstring& classname, const std::wstring
 
 	RECT	winRc = { 0, 0, window_client_size_.cx, window_client_size_.cy };
 	::AdjustWindowRectEx( &winRc, WS_OVERLAPPEDWINDOW, NULL, DEFAULT_EX_STYLE );
-	window_handle_ = ::CreateWindowEx( DEFAULT_EX_STYLE, window_class_name_.c_str(), window_title_.c_str(),
+	DWORD exStyle = DEFAULT_EX_STYLE;
+	if( hParent ) {
+		exStyle |= WS_EX_CONTROLPARENT;
+		has_parent_ = true;
+	}
+	window_handle_ = ::CreateWindowEx( exStyle, window_class_name_.c_str(), window_title_.c_str(),
 						WS_OVERLAPPEDWINDOW|WS_CLIPCHILDREN, CW_USEDEFAULT, CW_USEDEFAULT, winRc.right-winRc.left, winRc.bottom-winRc.top,
 						hParent, NULL, wc.hInstance, NULL );
 	
@@ -520,6 +525,9 @@ void tTVPWindow::SetBorderStyle(tTVPBorderStyle st) {
 	style &= ~notStyle;
 	DWORD exStyle = ::GetWindowLong( GetHandle(), GWL_EXSTYLE);
 	exStyle &= ~DEFAULT_EX_STYLE;
+	if( has_parent_ ) {
+		exStyle |= WS_EX_CONTROLPARENT;
+	}
 	border_style_ = static_cast<int>(st);
 	switch( st ) {
 	case bsDialog:
@@ -532,7 +540,12 @@ void tTVPWindow::SetBorderStyle(tTVPBorderStyle st) {
 		break;
 	case bsNone:
 		style |= WS_POPUP;
-		style |= WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SYSMENU;
+		style |= WS_MINIMIZEBOX;
+		if( has_parent_ ) {
+			exStyle |= WS_EX_TOOLWINDOW; // taskbar unlist
+		} else {
+			style |= WS_SYSMENU; // taskbar right click menu
+		}
 		break;
 	case bsSizeable:
 		style |= WS_CAPTION | WS_THICKFRAME;

--- a/src/core/environ/win32/TVPWindow.h
+++ b/src/core/environ/win32/TVPWindow.h
@@ -58,6 +58,8 @@ protected:
 	bool in_mode_;
 	int modal_result_;
 
+	bool has_parent_;
+
 	static const UINT SIZE_CHANGE_FLAGS;
 	static const UINT POS_CHANGE_FLAGS;
 	static const DWORD DEFAULT_EX_STYLE;
@@ -133,7 +135,7 @@ protected:
 public:
 	tTVPWindow()
 	: window_handle_(NULL), created_(false), left_double_click_(false), ime_control_(NULL), border_style_(0), modal_result_(0),
-		in_window_(false), ignore_touch_mouse_(false), in_mode_(false) {
+		in_window_(false), ignore_touch_mouse_(false), in_mode_(false), has_parent_(false) {
 		min_size_.cx = min_size_.cy = 0;
 		max_size_.cx = max_size_.cy = 0;
 	}


### PR DESCRIPTION
・親（オーナー）ウィンドウの有無を記すメンバ変数 has_parent_ の追加
・親がある場合 exStyle に WS_EX_CONTROLPARENT を追加するように調整
・bsNone時のstyle/exStyleを調整
＞親がある場合は style |= WS_POPUP | WS_MINIMIZEBOX, exStyle |= WS_EX_TOOLWINDOW
＞親がない場合は style |= WS_POPUP | WS_MINIMIZEBOX | WS_SYSMENU

WS_EX_TOOLWINDOWはタスクバーに表示させないようにするために追加します（設定してもウィンドウのボーダーはありません）
WS_SYSYMENUはタスクバーの右クリックメニューができるように追加します（最大化は不要なため、WS_MAXIMIZEBOXは外しました）
