### PR TITLE
正規表現の*などで空文字にマッチしてreplaceで無限ループなってしまう問題を修正

### DIFF
--- a/src/core/tjs2/tjsRegExp.cpp
+++ b/src/core/tjs2/tjsRegExp.cpp
@@ -35,7 +35,7 @@ static tjs_uint32 TJSRegExpFlagToValue(tjs_char ch, tjs_uint32 prev)
 	// when ch is '\0', returns default flag value and prev is ignored.
 
 	if(ch == 0) {
-		return ONIG_OPTION_DEFAULT|ONIG_OPTION_CAPTURE_GROUP;
+		return ONIG_OPTION_DEFAULT|ONIG_OPTION_CAPTURE_GROUP|ONIG_OPTION_FIND_NOT_EMPTY;
 	}
 
 	switch(ch)


### PR DESCRIPTION
再現コード例："abc012def".replace(/[0-9]*/g, "X");
*が0文字以上にマッチするため，冒頭の0,0範囲でマッチしてしまい，replaceで無限ループに陥る
⇒回避のためONIG_OPTION_FIND_NOT_EMPTYを指定
