### PR TITLE
Wiindow.ignoreTouchMouseプロパティを追加

### DIFF
--- a/src/core/environ/win32/TVPWindow.h
+++ b/src/core/environ/win32/TVPWindow.h
@@ -64,6 +64,7 @@ protected:
 	static const ULONG REGISTER_TOUCH_FLAG;
 
 	bool left_double_click_;
+	bool left_touch_down_;
 
 	ImeControl* ime_control_;
 
@@ -132,7 +133,7 @@ protected:
 	static bool HasMenu( HWND hWnd );
 public:
 	tTVPWindow()
-	: window_handle_(NULL), created_(false), left_double_click_(false), ime_control_(NULL), border_style_(0), modal_result_(0),
+	: window_handle_(NULL), created_(false), left_double_click_(false), left_touch_down_(false), ime_control_(NULL), border_style_(0), modal_result_(0),
 		in_window_(false), ignore_touch_mouse_(false), in_mode_(false) {
 		min_size_.cx = min_size_.cy = 0;
 		max_size_.cx = max_size_.cy = 0;
@@ -254,6 +255,9 @@ public:
 	void Close();
 
 	void GetClientRect( struct tTVPRect& rt );
+
+	bool GetIgnoreTouchMouse() const { return ignore_touch_mouse_; }
+	void SetIgnoreTouchMouse( bool b ) { ignore_touch_mouse_ = b; }
 
 	// メッセージハンドラ
 	virtual void OnActive( HWND preactive ) {}

--- a/src/core/visual/win32/WindowImpl.cpp
+++ b/src/core/visual/win32/WindowImpl.cpp
@@ -1913,6 +1913,18 @@ bool tTJSNI_Window::GetEnableTouch() const
 	return Form->GetEnableTouch();
 }
 //---------------------------------------------------------------------------
+void tTJSNI_Window::SetIgnoreTouchMouse( bool b )
+{
+	if(!Form) return;
+	Form->SetIgnoreTouchMouse(b);
+}
+//---------------------------------------------------------------------------
+bool tTJSNI_Window::GetIgnoreTouchMouse() const
+{
+	if(!Form) return 0;
+	return Form->GetIgnoreTouchMouse();
+}
+//---------------------------------------------------------------------------
 int tTJSNI_Window::GetDisplayOrientation()
 {
 	if(!Form) return orientUnknown;
@@ -2317,6 +2329,27 @@ TJS_BEGIN_NATIVE_PROP_DECL(enableTouch)
 	TJS_END_NATIVE_PROP_SETTER
 }
 TJS_END_NATIVE_PROP_DECL_OUTER(cls, enableTouch)
+//---------------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(ignoreTouchMouse)
+{
+	TJS_BEGIN_NATIVE_PROP_GETTER
+	{
+		TJS_GET_NATIVE_INSTANCE(/*var. name*/_this, /*var. type*/tTJSNI_Window);
+		*result = _this->GetIgnoreTouchMouse()?1:0;
+		return TJS_S_OK;
+	}
+	TJS_END_NATIVE_PROP_GETTER
+
+	TJS_BEGIN_NATIVE_PROP_SETTER
+	{
+		TJS_GET_NATIVE_INSTANCE(/*var. name*/_this, /*var. type*/tTJSNI_Window);
+		_this->SetIgnoreTouchMouse( ((tjs_int)*param) ? true : false );
+		return TJS_S_OK;
+	}
+	TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL_OUTER(cls, ignoreTouchMouse)
+//---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
 TJS_BEGIN_NATIVE_PROP_DECL(displayOrientation)
 {

--- a/src/core/visual/win32/WindowImpl.h
+++ b/src/core/visual/win32/WindowImpl.h
@@ -433,6 +433,9 @@ public:
 	void SetEnableTouch( bool b );
 	bool GetEnableTouch() const;
 
+	void SetIgnoreTouchMouse( bool b );
+	bool GetIgnoreTouchMouse() const;
+
 	int GetDisplayOrientation();
 	int GetDisplayRotate();
 	


### PR DESCRIPTION
- 概要：
  従来，タッチデバイスが有効な場合は{Window,Layer}.onTouch*イベントしか発行されない仕様になっていましたが，Windows側のタッチ操作のマウスイベントのエミュレーションを受け入れるかどうかを変更するプロパティを追加しました。
- 理由：
  onTouch系でUI操作する調整を入れてみたのですが，レイヤのマウスイベントキャプチャがなく，ドラッグ系操作に支障があったため（早く動かすと操作が追従しない）本体側で調整した方が良いという結論に至り，また，旧資産の互換性にも役に立つと思い，このプロパティを追加しました。
- 詳細：
  タッチデバイスが有効な場合はデフォルトでWindow.ignoreTouchMouse=trueとなります。（従来通りのタッチ操作のマウスイベントは無視する仕様）
  falseに設定するとタッチ操作によるマウスエミュレーション動作が有効になります。
  WM_LBUTTON\* イベントでのマウス／タッチ判定は GetMessageExtraInfo() の返り値で判定するように変更しました。
  ( http://msdn.microsoft.com/en-us/library/windows/desktop/ms703320(v=vs.85).aspx 参照)
  タッチ中にプロパティを変更されてMouseUpイベントが来ないのを防ぐため，left_touch_down_ メンバ変数を追加して判定してあります。
