### PR TITLE
マウスイベントのタッチ操作判定を変更／プレスアンドホールドの右クリック操作を無効化

### DIFF
--- a/src/core/environ/win32/TVPWindow.cpp
+++ b/src/core/environ/win32/TVPWindow.cpp
@@ -20,9 +20,8 @@
 #include <tpcshrd.h> // for MICROSOFT_TABLETPENSERVICE_PROPERTY
 
 // touch mouse message extraInfo (cf. http://msdn.microsoft.com/en-us/library/windows/desktop/ms703320(v=vs.85).aspx )
-#define MI_WP_SIGNATURE (0xFF515700)
-#define SIGNATURE_MASK  (0xFFFFFF00)
-#define IsTouchEvent(dw) (((dw) & SIGNATURE_MASK) == MI_WP_SIGNATURE)
+const DWORD tTVPWindow::MI_WP_SIGNATURE = 0xFF515700;
+const DWORD tTVPWindow::SIGNATURE_MASK  = 0xFFFFFF00;
 
 tTVPWindow::~tTVPWindow() {
 	if( ime_control_ ) delete ime_control_;

--- a/src/core/environ/win32/TVPWindow.h
+++ b/src/core/environ/win32/TVPWindow.h
@@ -64,6 +64,8 @@ protected:
 	static const DWORD DEFAULT_EX_STYLE;
 	static const ULONG REGISTER_TOUCH_FLAG;
 	static const DWORD DEFAULT_TABLETPENSERVICE_PROPERTY;
+	static const DWORD MI_WP_SIGNATURE;
+	static const DWORD SIGNATURE_MASK;
 
 	bool left_double_click_;
 
@@ -122,7 +124,10 @@ protected:
 		if(TVPGetAsyncKeyState(VK_MBUTTON)) s |= ssMiddle;
 		return s;
 	}
-	
+	inline bool IsTouchEvent(DWORD extraInfo) const {
+		return (extraInfo & SIGNATURE_MASK) == MI_WP_SIGNATURE;
+	}
+
 	void SetMouseCapture() {
 		::SetCapture( GetHandle() );
 	}


### PR DESCRIPTION
#137 からの修正／再リクエストとなります。

WM_MOUSE*イベントのタッチ判定は ::GetMessageExtraInfo() の値で判定できるため，そちらを使って判定するように変更しました。
それに伴い ignore_touch_mouse_ メンバ変数を削除しました。

WM_MOUSEMOVEでも判定有効なので，タッチ操作でOnMouseMoveを呼ばないようにしました。
（実マウスカーソル座標は移動しますが，吉里吉里側のイベントは飛びません）

プレスアンドホールドジェスチャで右クリックイベントが飛んできたので，これも無効化する設定にしました。
他，フィードバック系も無効にしてあります。tTVPWindow::DEFAULT_TABLETPENSERVICE_PROPERTY の設定を確認してください。
参考： http://msdn.microsoft.com/ja-jp/library/windows/desktop/dd562171(v=vs.85).aspx
