### PR TITLE
アプリケーションのActivate/Deactivate判定処理を修正（ #162 修正案）

### DIFF
--- a/src/core/environ/win32/Application.cpp
+++ b/src/core/environ/win32/Application.cpp
@@ -690,8 +690,6 @@ void tTVPApplication::CheckDigitizer() {
 }
 void tTVPApplication::OnActivate( HWND hWnd )
 {
-	OnActiveAnyWindow();
-
 	if( hWnd != GetMainWindowHandle() ) return;
 
 	application_activating_ = true;

--- a/src/core/environ/win32/TVPWindow.cpp
+++ b/src/core/environ/win32/TVPWindow.cpp
@@ -357,6 +357,9 @@ LRESULT WINAPI tTVPWindow::Proc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
 		// bpp, h resolution, v resolution
 		OnDisplayChange( wParam, LOWORD(lParam), HIWORD(lParam) );
 		break;
+	case WM_ACTIVATEAPP:
+		OnApplicationActivateChange( wParam != 0, (DWORD)lParam );
+		break;
 	default:
 		return ::DefWindowProc(hWnd,msg,wParam,lParam);
 	}

--- a/src/core/environ/win32/TVPWindow.h
+++ b/src/core/environ/win32/TVPWindow.h
@@ -300,6 +300,7 @@ public:
 	virtual void OnTouchSequenceEnd() {}
 
 	virtual void OnDisplayChange( DWORD bpp, WORD hres, WORD vres ) {}
+	virtual void OnApplicationActivateChange( bool activated, DWORD thread_id ) {}
 };
 
 #endif // __TVP_WINDOW_H__

--- a/src/core/environ/win32/WindowFormUnit.cpp
+++ b/src/core/environ/win32/WindowFormUnit.cpp
@@ -1707,15 +1707,22 @@ void TTVPWindowForm::OnActive( HWND preactive ) {
 	if( TVPFullScreenedWindow == this )
 		TVPShowModalAtAppActivate();
 
-	Application->OnActivate( GetHandle() );
+	Application->OnActiveAnyWindow();
 }
 void TTVPWindowForm::OnDeactive( HWND postactive ) {
 	if( TJSNativeInstance ) {
 		TVPPostInputEvent( new tTVPOnReleaseCaptureInputEvent(TJSNativeInstance) );
 	}
-
-	Application->OnDeactivate( GetHandle() );
 }
+void TTVPWindowForm::OnApplicationActivateChange( bool activated, DWORD thread_id ) {
+	if ( activated ) {
+		Application->OnActivate( GetHandle() );
+	} else {
+		Application->OnDeactivate( GetHandle() );
+	}
+}
+
+
 void TTVPWindowForm::OnMove( int x, int y ) {
 	if(TJSNativeInstance) {
 		TJSNativeInstance->WindowMoved();

--- a/src/core/environ/win32/WindowFormUnit.h
+++ b/src/core/environ/win32/WindowFormUnit.h
@@ -380,6 +380,8 @@ public:
 	virtual void OnDisplayChange( DWORD bpp, WORD hres, WORD vres );
 	virtual void OnDisplayRotate( int orientation, int rotate, int bpp, int hresolution, int vresolution );
 
+	virtual void OnApplicationActivateChange( bool activated, DWORD thread_id );
+
 	virtual void OnDestroy();
 	void WMShowVisible();
 	void WMShowTop( WPARAM wParam );


### PR DESCRIPTION
#162 修正案です。

- tTVPApplication::OnActivate冒頭にあるOnActiveAnyWindowを呼ぶ部分はカット
- TTVPWindowForm::OnActiveではApplication->OnActivateの代わりにOnActiveAnyWindowを呼ぶ
- TTVPWindowForm::OnDeactiveではApplication->OnDeactivateは呼ばない
- TTVPWindowForm::OnApplicationActivateChangeを作ってそちらからApplication->OnActivate/Deactivateを呼ぶ

追加関数名は若干長すぎる気がしますが，問題があれば適宜変更します…