### PR TITLE
#164 修正およびマウスカーソル形状変更周りの処理を改訂

### DIFF
--- a/src/core/environ/win32/MouseCursor.h
+++ b/src/core/environ/win32/MouseCursor.h
@@ -48,19 +48,15 @@ public:
 private:
 	int cursor_index_;
 
-	void UpdateCurrentCursor();
+	int GetCurrentCursor();
 
 public:
 	MouseCursor() : cursor_index_(INVALID_CURSOR_INDEX) {}
 	MouseCursor( int index ) : cursor_index_(index) {}
 
-	void SetCursor();
+	void UpdateCursor();
 
-	bool IsCurrentCursor( int index ) {
-		UpdateCurrentCursor();
-		return cursor_index_ == index;
-	}
-	void SetCursorIndex( int index );
+	void SetCursorIndex( int index, HWND hWnd );
 };
 
 #endif

--- a/src/core/environ/win32/TVPWindow.cpp
+++ b/src/core/environ/win32/TVPWindow.cpp
@@ -324,6 +324,9 @@ LRESULT WINAPI tTVPWindow::Proc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
 		return 0;
 	case WM_MOUSEACTIVATE:
 		return OnMouseActivate( reinterpret_cast<HWND>(wParam), LOWORD(lParam), HIWORD(lParam) );
+	case WM_SETCURSOR:
+		if( OnSetCursor( reinterpret_cast<HWND>(wParam), LOWORD(lParam), HIWORD(lParam) ) ) return 1;
+		break;
 	case WM_ENABLE:
 		OnEnable( wParam != 0 );
 		break;

--- a/src/core/environ/win32/TVPWindow.h
+++ b/src/core/environ/win32/TVPWindow.h
@@ -283,6 +283,7 @@ public:
 	virtual void OnResize( int state, int w, int h ) {}
 	virtual void OnDropFile( HDROP hDrop ) {}
 	virtual int OnMouseActivate( HWND hTopLevelParentWnd, WORD hitTestCode, WORD MouseMsg ) { return MA_ACTIVATE; }
+	virtual bool OnSetCursor( HWND hContainsCursorWnd, WORD hitTestCode, WORD MouseMsg ) { return false; }
 	virtual void OnEnable( bool enabled ) {}
 	virtual void OnEnterMenuLoop( bool entered ) {}
 	virtual void OnExitMenuLoop( bool isShortcutMenu ) {}

--- a/src/core/environ/win32/WindowFormUnit.h
+++ b/src/core/environ/win32/WindowFormUnit.h
@@ -154,7 +154,8 @@ private:
 	//-- mouse cursor
 	tTVPMouseCursorState MouseCursorState;
 	bool ForceMouseCursorVisible; // true in menu select
-	MouseCursor CurrentMouseCursor;
+	MouseCursor MouseCursorManager;
+	tjs_int CurrentMouseCursor;
 	tjs_int LastMouseScreenX; // managed by RestoreMouseCursor
 	tjs_int LastMouseScreenY;
 
@@ -248,7 +249,7 @@ public:
 	void SetMaskRegion(HRGN threshold);
 	void RemoveMaskRegion();
 
-	void SetMouseCursorToWindow( MouseCursor& cursor );
+	void SetMouseCursorToWindow( tjs_int cursor );
 
 	void HideMouseCursor();
 	void SetMouseCursorState(tTVPMouseCursorState mcs);
@@ -356,14 +357,17 @@ public:
 	virtual void OnResize( int state, int w, int h );
 	virtual void OnDropFile( HDROP hDrop );
 	virtual int OnMouseActivate( HWND hTopLevelParentWnd, WORD hitTestCode, WORD MouseMsg );
+	virtual bool OnSetCursor( HWND hContainsCursorWnd, WORD hitTestCode, WORD MouseMsg );
 	virtual void OnEnable( bool enabled );
 	virtual void OnDeviceChange( int event, void *data );
 	virtual void OnNonClientMouseDown( int button, int hittest, int x, int y );
 	virtual void OnMouseEnter();
 	virtual void OnMouseLeave();
+	virtual void OnEnterMenuLoop( bool entered );
+	virtual void OnExitMenuLoop( bool isShortcutMenu );
 	virtual void OnShow( int status );
 	virtual void OnHide( int status );
-	
+
 	virtual void OnFocus(HWND hFocusLostWnd);
 	virtual void OnFocusLost(HWND hFocusingWnd);
 	


### PR DESCRIPTION
・WM_SETCURSORメッセージハンドラTVPWindow::OnSetCursorを追加
・OnEnterMenuLoop～OnExitMenuLoop間においてSetForceMouseCursorVisibleで常にマウスカーソルを表示する調整を追加（吉里吉里２でも同じような実装あり）
・WindowFormUnit::CurrentMouseCursorをMouseCursorインスタンスからカーソルのインデックスを保持する変数に変更（吉里吉里２実装準拠）
・MouseCursorクラスをカーソル管理クラスとしてWindowFormUnit::MouseCursorManagerとして保持（吉里吉里２でのPaintBox->Cursor相当の役割）
・MouseCursorクラス内の実装を大幅改訂，カーソル消去は::ShowCursor(FALSE)から::SetCursor(NULL)へ変更