### PR TITLE
#171 修正

### DIFF
--- a/src/core/environ/win32/TVPWindow.cpp
+++ b/src/core/environ/win32/TVPWindow.cpp
@@ -20,8 +20,8 @@
 #include <tpcshrd.h> // for MICROSOFT_TABLETPENSERVICE_PROPERTY
 
 // touch mouse message extraInfo (cf. http://msdn.microsoft.com/en-us/library/windows/desktop/ms703320(v=vs.85).aspx )
-const DWORD tTVPWindow::MI_WP_SIGNATURE = 0xFF515700;
-const DWORD tTVPWindow::SIGNATURE_MASK  = 0xFFFFFF00;
+const DWORD tTVPWindow::MI_WP_SIGNATURE = 0xFF515780;
+const DWORD tTVPWindow::SIGNATURE_MASK  = 0xFFFFFF80;
 
 tTVPWindow::~tTVPWindow() {
 	if( ime_control_ ) delete ime_control_;


### PR DESCRIPTION
#171 より
tTVPWindow::IsTouchEvent()でペンデバイスは判定対象外とする修正になります