### PR TITLE
#237 operateAffine 実行時にハードウェア例外が発生する場合があるのを修正。

### DIFF
--- a/src/core/visual/gl/blend_function_sse2.cpp
+++ b/src/core/visual/gl/blend_function_sse2.cpp
@@ -707,6 +707,7 @@ void sse2_interpolation_line_transform_copy(tjs_uint32 *dest, tjs_int len, const
 			mxy = _mm_add_epi32( mxy, mstep1 );	// sx,sy += stepx,stepy
 			dest++;
 		}
+		len -= count;
 	}
 
 	tjs_uint32 rem = (len>>2)<<2;

--- a/src/core/visual/gl/univtrans_sse2.cpp
+++ b/src/core/visual/gl/univtrans_sse2.cpp
@@ -306,6 +306,7 @@ static inline void sse2_univ_trans_switch(tjs_uint32 *dest, const tjs_uint32 *sr
 				dest++; src1++; src2++, rule++;
 			}
 		}
+		len -= count;
 	}
 	tjs_uint32 rem = (len>>2)<<2;
 	tjs_uint32* limit = dest + rem;


### PR DESCRIPTION
#237 operateAffine 実行時にハードウェア例外が発生する場合があるのを修正。
universalトランジションでも起こりえたので同様に修正。