### PR TITLE
#241 H.264/WMVオープンエラー修正。動画プラグイン追加時の不具合も修正。

### DIFF
--- a/src/core/movie/win32/CWMReader.cpp
+++ b/src/core/movie/win32/CWMReader.cpp
@@ -320,7 +320,7 @@ HRESULT CWMReader::OpenStream( IStream *stream )
 		if( m_WmvDll.IsLoaded() == false )
 			return m_WmvDll.GetLastError();
 
-		typedef HRESULT (*FuncWMCreateSyncReader)( IUnknown *pUnkCert, DWORD dwRights, IWMSyncReader **ppSyncReader );
+		typedef HRESULT (WINAPI *FuncWMCreateSyncReader)( IUnknown *pUnkCert, DWORD dwRights, IWMSyncReader **ppSyncReader );
 		FuncWMCreateSyncReader pWMCreateSyncReader = (FuncWMCreateSyncReader)m_WmvDll.GetProcAddress("WMCreateSyncReader");
 		if( pWMCreateSyncReader == NULL )
 			return m_WmvDll.GetLastError();

--- a/src/core/movie/win32/MFPlayer.cpp
+++ b/src/core/movie/win32/MFPlayer.cpp
@@ -181,7 +181,7 @@ void __stdcall tTVPMFPlayer::BuildGraph( HWND callbackwin, IStream *stream,
 	HRESULT hr = S_OK;
 	// MFCreateMFByteStreamOnStream は、Windows 7 以降にのみある API なので、動的ロードして Vista での起動に支障がないようにする
 	if( MfplatDLL.IsLoaded() == false ) MfplatDLL.Load(L"mfplat.dll");
-	typedef HRESULT (*FuncMFCreateMFByteStreamOnStream)(IStream *pStream,IMFByteStream **ppByteStream);
+	typedef HRESULT (WINAPI *FuncMFCreateMFByteStreamOnStream)(IStream *pStream,IMFByteStream **ppByteStream);
 	FuncMFCreateMFByteStreamOnStream pCreateMFByteStream = (FuncMFCreateMFByteStreamOnStream)MfplatDLL.GetProcAddress("MFCreateMFByteStreamOnStream");
 	if( pCreateMFByteStream == NULL ) {
 		TVPThrowExceptionMessage(L"Faild to retrieve MFCreateMFByteStreamOnStream from mfplat.dll.");

--- a/src/core/movie/win32/TVPVideoOverlay.cpp
+++ b/src/core/movie/win32/TVPVideoOverlay.cpp
@@ -98,9 +98,10 @@ tTVPDSFilterHandlerType* TVPGetDSFilterHandler( const GUID& guid )
 	tTJSHashTable<ttstr, tTVPDSFilterHandlerType>::tIterator i;
 	for(i = TVPDSFilterType.Hash.GetFirst(); !i.IsNull(); i++)
 	{
-		handler = & i.GetValue();
-		if( IsEqualGUID( guid, *handler->Guid ) )
+		tTVPDSFilterHandlerType *value = & i.GetValue();
+		if( IsEqualGUID( guid, *value->Guid ) )
 		{
+			handler = value;
 			break;
 		}
 	}


### PR DESCRIPTION
#241 H.264/WMVオープンエラーを修正。
動画プラグイン追加時に指定動画に該当するプラグインがない場合に最後のプラグインを参照してしまう不具合を修正。