### PR TITLE
#248 SSE4.1がサポートされていないCPUでstretchCopyを実行するとエラーで終了する不具合を修正

### DIFF
--- a/src/core/visual/gl/ResampleImageSSE2.cpp
+++ b/src/core/visual/gl/ResampleImageSSE2.cpp
@@ -835,7 +835,7 @@ public:
 			}
 			{	// SSE
 				__m128i color = _mm_cvtps_epi32( color_elm );
-				color = _mm_packus_epi32( color, color );
+				color = _mm_packs_epi32( color, color );
 				color = _mm_packus_epi16( color, color );
 				*dstbits = _mm_cvtsi128_si32( color );
 			}


### PR DESCRIPTION
一か所SSE4.1の命令を使用してしまっていた