### PR TITLE
Bitmapメモリ確保方法をプロセスヒープから行うように変更

### DIFF
--- a/src/core/vc2012/option_desc_ja.json
+++ b/src/core/vc2012/option_desc_ja.json
@@ -659,7 +659,8 @@
 				"type":"select",
 				"user":true,
 				"values":[
-					{ "value":"globalalloc", "desc":"GlobalAllocで確保", "default":true },
+					{ "value":"processheap", "desc":"プロセスヒープを使用", "default":true },
+					{ "value":"globalalloc", "desc":"GlobalAllocで確保" },
 					{ "value":"separateheap", "desc":"分割ヒープを使用" },
 					{ "value":"malloc", "desc":"mallocを使用" }
 				]


### PR DESCRIPTION
大画面化に伴いBitmapメモリ確保に失敗する事例が増えてきたため、メモリ確保方法をプロセスヒープから行うように変更