### PR TITLE
#236 ロック画面での描画でメモリ消費量が増大する問題を修正。

### DIFF
--- a/src/core/visual/win32/BasicDrawDevice.cpp
+++ b/src/core/visual/win32/BasicDrawDevice.cpp
@@ -350,6 +350,10 @@ void tTVPBasicDrawDevice::TryRecreateWhenDeviceLost()
 		if( hr == D3DERR_DEVICENOTRESET ) {
 			hr = Direct3DDevice->Reset(&D3dPP);
 		}
+		if( hr == D3DERR_DEVICELOST ) {
+			// •œ‹A‚Å‚«‚È‚¢
+			return;
+		}
 		if( FAILED(hr) ) {
 			success = CreateD3DDevice();
 		} else {


### PR DESCRIPTION
Direct3Dデバイスがロストした時、強制的に破棄して作り直すのではなく、リセットによる復帰を優先するように修正した。