### PR TITLE
32コア以上で問題が起きる件について、暫定対応としてプロセスのコア数を制限する内部オプションを追加。

### DIFF
--- a/vcproj/option_desc_ja.json
+++ b/vcproj/option_desc_ja.json
@@ -889,6 +889,17 @@
 					{ "value":"no", "desc":"使用可能であっても使用しない" },
 					{ "value":"force", "desc":"強制的に使用する" }
 				]
+			},
+			{
+				"caption":"Core Limitation",
+				"description":"動作に問題が起こった時に調整してください。",
+				"name":"cpucorelimit",
+				"type":"select",
+				"user":false,
+				"values":[
+					{ "value":"yes", "desc":"制限する", "default":true },
+					{ "value":"no", "desc":"制限しない" },
+				]
 			}
 		]
 	},


### PR DESCRIPTION
32コア以上で問題が起きる件について、暫定対応としてプロセスのコア数を制限する内部オプションを追加。