### PR TITLE
fix: syntax error

### DIFF
--- a/vcproj/option_desc_ja.json
+++ b/vcproj/option_desc_ja.json
@@ -898,7 +898,7 @@
 				"user":false,
 				"values":[
 					{ "value":"yes", "desc":"制限する", "default":true },
-					{ "value":"no", "desc":"制限しない" },
+					{ "value":"no", "desc":"制限しない" }
 				]
 			}
 		]


### PR DESCRIPTION
901 行目の { "value":"no", "desc":"制限しない" }, に行末の ',' があるため syntax error を起こしています。

そのため、このままビルドした tvpwin32.exe, tvpwin64.exe は -userconf 付きで起動した際設定項目を表示できません。

https://krkrz.github.io/ に公開されている krkrz_20171225r2.7z (1.4.0) に同梱されている tvpwin32/64.exe も全てこれが原因で -userconf 付きで起動した際設定項目を表示できないものが同梱されているので差し替えが必要と思います。