### PR TITLE
Don't add additional bold/italic if font face is already bold/italic

### DIFF
--- a/visual/FreeType.cpp
+++ b/visual/FreeType.cpp
@@ -1093,8 +1093,8 @@ tjs_int tFreeTypeFace::LoadGlyphSlotFromCharcode(tjs_char code)
 		if(err) continue;
 
 		// フォントの変形を行う
-		if( Options & TVP_TF_BOLD ) FT_GlyphSlot_Embolden( faceset->FTFace->glyph );
-		if( Options & TVP_TF_ITALIC ) FT_GlyphSlot_Oblique( faceset->FTFace->glyph );
+		if( (Options & TVP_TF_BOLD) && !(faceset->FTFace->style_flags & FT_STYLE_FLAG_BOLD) ) FT_GlyphSlot_Embolden( faceset->FTFace->glyph );
+		if( (Options & TVP_TF_ITALIC) && !(faceset->FTFace->style_flags & FT_STYLE_FLAG_ITALIC) ) FT_GlyphSlot_Oblique( faceset->FTFace->glyph );
 
 		return (tjs_int)i;
 	}


### PR DESCRIPTION
On line 316 of `visual/FreeType.cpp`, the bold/italic font face will be selected if it exists.  

Applying the bold/italic transforms will make the font face less presentable, so don't apply the transforms if that is the case.  