### PR TITLE
Reduce complexity of string comparisons

### DIFF
--- a/base/EventIntf.cpp
+++ b/base/EventIntf.cpp
@@ -18,6 +18,7 @@
 #include "MsgIntf.h"
 #include "ScriptMgnIntf.h"
 #include "TickCount.h"
+#include "tjsGlobalStringMap.h"
 
 
 
@@ -875,8 +876,8 @@ iTJSDispatch2 * TVPCreateEventObject(const tjs_char *type,
 	// create a dictionary object for event dispatching ( to "action" method )
 	iTJSDispatch2 * object = TJSCreateDictionaryObject();
 
-	static ttstr type_name(TJS_W("type"));
-	static ttstr target_name(TJS_W("target"));
+	static ttstr type_name(TJSMapGlobalStringMap(TJS_W("type")));
+	static ttstr target_name(TJSMapGlobalStringMap(TJS_W("target")));
 
 	{
 		tTJSVariant val(type);
@@ -1234,7 +1235,7 @@ void tTJSNI_AsyncTrigger::Trigger()
 			// remove undelivered events from queue when "Cached" flag is set
 			TVPCancelSourceEvents(Owner);
 		}
-		static ttstr eventname(TJS_W("onFire"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onFire")));
 
 		tjs_uint32 flags = TVP_EPT_POST;
 		if(Mode == atmExclusive) flags |= TVP_EPT_EXCLUSIVE;  // fire exclusive event

--- a/base/EventIntf.h
+++ b/base/EventIntf.h
@@ -14,6 +14,7 @@
 #define EventIntfH
 
 #include "tjsNative.h"
+#include "tjsGlobalStringMap.h"
 
 
 
@@ -203,7 +204,7 @@ extern ttstr TVPActionName;
 
 #define TVP_ACTION_INVOKE_MEMBER(name) \
 	{\
-		static ttstr member_name(TJS_W(name)); \
+		static ttstr member_name(TJSMapGlobalStringMap(TJS_W(name))); \
 		evobj->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP, \
 			member_name.c_str(), member_name.GetHint(), param[arg_count++], \
 			evobj); \

--- a/base/ScriptMgnIntf.cpp
+++ b/base/ScriptMgnIntf.cpp
@@ -40,6 +40,7 @@
 #include "SysInitImpl.h"
 #include "SystemControl.h"
 #include "Application.h"
+#include "tjsGlobalStringMap.h"
 
 #include "RectItf.h"
 #include "ImageFunction.h"
@@ -193,7 +194,8 @@ void TVPInitScriptEngine()
 	dsp = (instance); \
 	val = tTJSVariant(dsp/*, dsp*/); \
 	dsp->Release(); \
-	global->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP, TJS_W(#classname), NULL, \
+	static ttstr classname##_name(TJSMapGlobalStringMap(TJS_W(#classname))); \
+	global->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP, classname##_name.c_str(), classname##_name.GetHint(), \
 		&val, global);
 
 	/* classes */
@@ -227,8 +229,9 @@ void TVPInitScriptEngine()
 	dsp = new tTJSNC_PhaseVocoder();
 	val = tTJSVariant(dsp);
 	dsp->Release();
+	static ttstr PhaseVocoder_name(TJSMapGlobalStringMap(TJS_W("PhaseVocoder")));
 	waveclass->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP|TJS_STATICMEMBER,
-		TJS_W("PhaseVocoder"), NULL, &val, waveclass);
+		PhaseVocoder_name.c_str(), PhaseVocoder_name.GetHint(), &val, waveclass);
 
 	/* Window and its drawdevices */
 	iTJSDispatch2 * windowclass = NULL;
@@ -237,8 +240,9 @@ void TVPInitScriptEngine()
 	dsp = new tTJSNC_BasicDrawDevice();
 	val = tTJSVariant(dsp);
 	dsp->Release();
+	static ttstr BasicDrawDevice_name(TJSMapGlobalStringMap(TJS_W("BasicDrawDevice")));
 	windowclass->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP|TJS_STATICMEMBER,
-		TJS_W("BasicDrawDevice"), NULL, &val, windowclass);
+		BasicDrawDevice_name.c_str(), BasicDrawDevice_name.GetHint(), &val, windowclass);
 #endif
 	// Add Extension Classes
 	TVPCauseAtInstallExtensionClass( global );
@@ -605,7 +609,8 @@ static bool  TJSGetSystem_exceptionHandler_Object(tTJSVariantClosure & dest)
 	tTJSVariantClosure clo;
 
 	tjs_error er;
-	er = global->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("System"), NULL, &val, global);
+	static ttstr System_name(TJSMapGlobalStringMap(TJS_W("System")));
+	er = global->PropGet(TJS_MEMBERMUSTEXIST, System_name.c_str(), System_name.GetHint(), &val, global);
 	if(TJS_FAILED(er)) return false;
 
 	if(val.Type() != tvtObject) return false;
@@ -614,7 +619,8 @@ static bool  TJSGetSystem_exceptionHandler_Object(tTJSVariantClosure & dest)
 
 	if(clo.Object == NULL) return false;
 
-	clo.PropGet(TJS_MEMBERMUSTEXIST, TJS_W("exceptionHandler"), NULL, &val2, NULL);
+	static ttstr exceptionHandler_name(TJSMapGlobalStringMap(TJS_W("exceptionHandler")));
+	clo.PropGet(TJS_MEMBERMUSTEXIST, exceptionHandler_name.c_str(), exceptionHandler_name.GetHint(), &val2, NULL);
 
 	if(val2.Type() != tvtObject) return false;
 

--- a/base/SystemIntf.cpp
+++ b/base/SystemIntf.cpp
@@ -22,6 +22,7 @@
 #include "Random.h"
 #include "ScriptMgnIntf.h"
 #include "DebugIntf.h"
+#include "tjsGlobalStringMap.h"
 
 extern int TVPGetOpenGLESVersion();
 
@@ -48,7 +49,8 @@ void TVPFireOnApplicationActivateEvent(bool activate_or_deactivate)
 	try
 	{
 		tjs_error er;
-		er = global->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("System"), NULL, &val, global);
+		static ttstr System_name(TJSMapGlobalStringMap(TJS_W("System")));
+		er = global->PropGet(TJS_MEMBERMUSTEXIST, System_name.c_str(), System_name.GetHint(), &val, global);
 		if(TJS_FAILED(er)) return;
 
 		if(val.Type() != tvtObject) return;
@@ -57,11 +59,16 @@ void TVPFireOnApplicationActivateEvent(bool activate_or_deactivate)
 
 		if(clo.Object == NULL) return;
 
+		static ttstr onActivate_name(TJSMapGlobalStringMap(TJS_W("onActivate")));
+		static ttstr onDeactivate_name(TJSMapGlobalStringMap(TJS_W("onDeactivate")));
 		clo.PropGet(TJS_MEMBERMUSTEXIST,
 				activate_or_deactivate?
-					TJS_W("onActivate"):
-					TJS_W("onDeactivate"),
-			NULL, &val2, NULL);
+					onActivate_name.c_str():
+					onDeactivate_name.c_str(),
+				activate_or_deactivate?
+					onActivate_name.GetHint():
+					onDeactivate_name.GetHint(),
+			&val2, NULL);
 
 		if(val2.Type() != tvtObject) return;
 
@@ -496,11 +503,14 @@ TJS_END_NATIVE_STATIC_PROP_DECL(openGLESVersion)
 
 	// register default "exceptionHandler" member
 	tTJSVariant val((iTJSDispatch2*)NULL, (iTJSDispatch2*)NULL);
-	PropSet(TJS_MEMBERENSURE, TJS_W("exceptionHandler"), NULL, &val, this);
+	static ttstr exceptionHandler_name(TJSMapGlobalStringMap(TJS_W("exceptionHandler")));
+	PropSet(TJS_MEMBERENSURE, exceptionHandler_name.c_str(), exceptionHandler_name.GetHint(), &val, this);
 
 	// and onActivate, onDeactivate
-	PropSet(TJS_MEMBERENSURE, TJS_W("onActivate"), NULL, &val, this);
-	PropSet(TJS_MEMBERENSURE, TJS_W("onDeactivate"), NULL, &val, this);
+	static ttstr onActivate_name(TJSMapGlobalStringMap(TJS_W("onActivate")));
+	PropSet(TJS_MEMBERENSURE, onActivate_name.c_str(), onActivate_name.GetHint(), &val, this);
+	static ttstr onDeactivate_name(TJSMapGlobalStringMap(TJS_W("onDeactivate")));
+	PropSet(TJS_MEMBERENSURE, onDeactivate_name.c_str(), onDeactivate_name.GetHint(), &val, this);
 }
 //---------------------------------------------------------------------------
 tTJSNativeInstance * tTJSNC_System::CreateNativeInstance()

--- a/base/android/SystemImpl.cpp
+++ b/base/android/SystemImpl.cpp
@@ -29,6 +29,7 @@
 //#include "CompatibleNativeFuncs.h"
 #include "DebugIntf.h"
 #include "CharacterSet.h"
+#include "tjsGlobalStringMap.h"
 
 
 #define ANDROID_BUILDING_DISABLE
@@ -98,7 +99,7 @@ bool TVPGetAsyncKeyState(tjs_uint keycode, bool getcurrent)
 //---------------------------------------------------------------------------
 ttstr TVPGetPlatformName()
 {
-	static ttstr platform(TJS_W("Android"));
+	static ttstr platform(TJSMapGlobalStringMap(TJS_W("Android")));
 	return platform;
 }
 //---------------------------------------------------------------------------
@@ -452,7 +453,7 @@ TJS_BEGIN_NATIVE_PROP_DECL(exeName)
 {
 	TJS_BEGIN_NATIVE_PROP_GETTER
 	{
-		static ttstr exename(TVPNormalizeStorageName(Application->GetPackageCodePath()));
+		static ttstr exename(TJSMapGlobalStringMap(TVPNormalizeStorageName(Application->GetPackageCodePath())));
 		*result = exename;
 		return TJS_S_OK;
 	}

--- a/base/stub/StorageImpl.cpp
+++ b/base/stub/StorageImpl.cpp
@@ -21,6 +21,7 @@
 #include "XP3Archive.h"
 #include "FileSelector.h"
 #include "Random.h"
+#include "tjsGlobalStringMap.h"
 
 #include "Application.h"
 #include "StringUtil.h"
@@ -343,7 +344,7 @@ bool TVPRemoveFolder(const ttstr &name)
 //---------------------------------------------------------------------------
 ttstr TVPGetAppPath()
 {
-	static ttstr exepath(TVPExtractStoragePath(TVPNormalizeStorageName(ExePath())));
+	static ttstr exepath(TJSMapGlobalStringMap(TVPExtractStoragePath(TVPNormalizeStorageName(ExePath()))));
 	return exepath;
 }
 //---------------------------------------------------------------------------

--- a/base/stub/SystemImpl.cpp
+++ b/base/stub/SystemImpl.cpp
@@ -25,6 +25,7 @@
 #include "WindowImpl.h"
 #include "SystemControl.h"
 #include "DInputMgn.h"
+#include "tjsGlobalStringMap.h"
 
 #include "Application.h"
 #include "TVPScreen.h"
@@ -98,7 +99,7 @@ bool TVPGetAsyncKeyState(tjs_uint keycode, bool getcurrent)
 //---------------------------------------------------------------------------
 ttstr TVPGetPlatformName()
 {
-	static ttstr platform(TJS_W("Win32"));
+	static ttstr platform(TJSMapGlobalStringMap(TJS_W("Win32")));
 	return platform;
 }
 //---------------------------------------------------------------------------
@@ -873,7 +874,7 @@ TJS_BEGIN_NATIVE_PROP_DECL(exeName)
 {
 	TJS_BEGIN_NATIVE_PROP_GETTER
 	{
-		static ttstr exename(TVPNormalizeStorageName(ExePath()));
+		static ttstr exename(TJSMapGlobalStringMap(TVPNormalizeStorageName(ExePath())));
 		*result = exename;
 		return TJS_S_OK;
 	}

--- a/base/win32/FileSelector.cpp
+++ b/base/win32/FileSelector.cpp
@@ -18,6 +18,7 @@
 #include "WindowImpl.h"
 #include "SysInitIntf.h"
 #include "DebugIntf.h"
+#include "tjsGlobalStringMap.h"
 
 #include "TVPScreen.h"
 
@@ -122,7 +123,8 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 		// get filter
 		ofn.lpstrFilter = NULL;
 
-		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("filter"), 0,
+		static ttstr filter_name(TJSMapGlobalStringMap(TJS_W("filter")));
+		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, filter_name.c_str(), filter_name.GetHint(),
 			&val, params)))
 		{
 			std::vector<tjs_string> filterlist;
@@ -135,8 +137,9 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 				iTJSDispatch2 * array = val.AsObjectNoAddRef();
 				tjs_int count;
 				tTJSVariant tmp;
+				static ttstr count_name(TJSMapGlobalStringMap(TJS_W("count")));
 				if(TJS_SUCCEEDED(array->PropGet(TJS_MEMBERMUSTEXIST,
-					TJS_W("count"), 0, &tmp, array)))
+					count_name.c_str(), count_name.GetHint(), &tmp, array)))
 					count = tmp;
 				else
 					count = 0;
@@ -175,7 +178,8 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 		ofn.lpstrCustomFilter = NULL;
 		ofn.nMaxCustFilter = 0;
 
-		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("filterIndex"), 0, &val, params)))
+		static ttstr filterIndex_name(TJSMapGlobalStringMap(TJS_W("filterIndex")));
+		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, filterIndex_name.c_str(), filterIndex_name.GetHint(), &val, params)))
 			ofn.nFilterIndex = (tjs_int)val;
 		else
 			ofn.nFilterIndex = 0;
@@ -184,7 +188,8 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 		filename = new tjs_char[MAX_PATH + 1];
  		filename[0] = 0;
 
-		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("name"), 0, &val, params)))
+ 		static ttstr name_name(TJSMapGlobalStringMap(TJS_W("name")));
+		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, name_name.c_str(), name_name.GetHint(), &val, params)))
 		{
 			ttstr lname(val);
 			if(!lname.IsEmpty())
@@ -204,7 +209,8 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 
 		// initial dir
 		ofn.lpstrInitialDir = NULL;
-		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("initialDir"), 0, &val, params)))
+		static ttstr initialDir_name(TJSMapGlobalStringMap(TJS_W("initialDir")));
+		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, initialDir_name.c_str(), initialDir_name.GetHint(), &val, params)))
 		{
 			ttstr lname(val);
 			if(!lname.IsEmpty())
@@ -217,7 +223,8 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 		}
 	
 		// title
-		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("title"), 0, &val, params)))
+		static ttstr title_name(TJSMapGlobalStringMap(TJS_W("title")));
+		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, title_name.c_str(), title_name.GetHint(), &val, params)))
 		{
 			title = ttstr(val).AsStdString();
 			ofn.lpstrTitle = title.c_str();
@@ -229,7 +236,8 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 
 		// flags
 		bool issave = false;
-		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("save"), 0, &val, params)))
+		static ttstr save_name(TJSMapGlobalStringMap(TJS_W("save")));
+		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, save_name.c_str(), save_name.GetHint(), &val, params)))
 			issave = val.operator bool();
 
 		ofn.Flags = OFN_ENABLEHOOK|OFN_EXPLORER|OFN_NOCHANGEDIR|
@@ -242,7 +250,8 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 			ofn.Flags |= OFN_OVERWRITEPROMPT;
 
 		// default extension
-		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("defaultExt"), 0, &val, params)))
+		static ttstr defaultExt_name(TJSMapGlobalStringMap(TJS_W("defaultExt")));
+		if(TJS_SUCCEEDED(params->PropGet(TJS_MEMBERMUSTEXIST, defaultExt_name.c_str(), defaultExt_name.GetHint(), &val, params)))
 		{
 			defaultext = ttstr(val).AsStdString();
 			ofn.lpstrDefExt = defaultext.c_str();
@@ -279,11 +288,13 @@ bool TVPSelectFile(iTJSDispatch2 *params)
 
 			// filter index
 			val = (tjs_int)ofn.nFilterIndex;
-			params->PropSet(TJS_MEMBERENSURE, TJS_W("filterIndex"), 0, &val, params);
+			static ttstr filterIndex_name(TJSMapGlobalStringMap(TJS_W("filterIndex")));
+			params->PropSet(TJS_MEMBERENSURE, filterIndex_name.c_str(), filterIndex_name.GetHint(), &val, params);
 
 			// file name
 			val = TVPNormalizeStorageName(ttstr(filename));
-			params->PropSet(TJS_MEMBERENSURE, TJS_W("name"), 0, &val, params);
+			static ttstr name_name(TJSMapGlobalStringMap(TJS_W("name")));
+			params->PropSet(TJS_MEMBERENSURE, name_name.c_str(), name_name.GetHint(), &val, params);
 		}
 
 	}

--- a/base/win32/StorageImpl.cpp
+++ b/base/win32/StorageImpl.cpp
@@ -25,6 +25,7 @@
 #include "SusieArchive.h"
 #include "FileSelector.h"
 #include "Random.h"
+#include "tjsGlobalStringMap.h"
 
 #include <time.h>
 
@@ -281,6 +282,7 @@ ttstr TVPGetTemporaryName()
 			TVPTempPath = tmp;
 
 			if(TVPTempPath.GetLastChar() != TJS_W('\\')) TVPTempPath += TJS_W("\\");
+			TVPTempPath = TJSMapGlobalStringMap(TVPTempPath);
 			TVPProcessID = (tjs_int) GetCurrentProcessId();
 			TVPTempUniqueNum = (tjs_int) GetTickCount();
 			TVPTempPathInit = true;
@@ -333,7 +335,7 @@ bool TVPRemoveFolder(const ttstr &name)
 //---------------------------------------------------------------------------
 ttstr TVPGetAppPath()
 {
-	static ttstr exepath(TVPExtractStoragePath(TVPNormalizeStorageName(ExePath())));
+	static ttstr exepath(TJSMapGlobalStringMap(TVPExtractStoragePath(TVPNormalizeStorageName(ExePath()))));
 	return exepath;
 }
 //---------------------------------------------------------------------------

--- a/base/win32/SystemImpl.cpp
+++ b/base/win32/SystemImpl.cpp
@@ -25,6 +25,7 @@
 #include "WindowImpl.h"
 #include "SystemControl.h"
 #include "DInputMgn.h"
+#include "tjsGlobalStringMap.h"
 
 #include "Application.h"
 #include "TVPScreen.h"
@@ -1014,7 +1015,7 @@ TJS_BEGIN_NATIVE_PROP_DECL(exeName)
 {
 	TJS_BEGIN_NATIVE_PROP_GETTER
 	{
-		static ttstr exename(TVPNormalizeStorageName(ExePath()));
+		static ttstr exename(TJSMapGlobalStringMap(TVPNormalizeStorageName(ExePath())));
 		*result = exename;
 		return TJS_S_OK;
 	}

--- a/environ/android/Application.cpp
+++ b/environ/android/Application.cpp
@@ -43,6 +43,7 @@
 #include "FontSystem.h"
 #include "GraphicsLoadThread.h"
 #include "MsgLoad.h"
+#include "tjsGlobalStringMap.h"
 
 #include <ft2build.h>
 #include FT_TRUETYPE_UNPATENTED_H
@@ -545,6 +546,7 @@ const ttstr &TVPGetDefaultFaceNames() {
 		} else {
 			TVPDefaultFaceNames += ttstr(TJS_W(",Roboto"));
 		}
+		TVPDefaultFaceNames = TJSMapGlobalStringMap(TVPDefaultFaceNames);
 		return TVPDefaultFaceNames;
 	}
 }

--- a/environ/win32/WindowFormUnit.cpp
+++ b/environ/win32/WindowFormUnit.cpp
@@ -22,6 +22,7 @@
 #include "SystemImpl.h"
 #include "DInputMgn.h"
 #include "tvpinputdefs.h"
+#include "tjsGlobalStringMap.h"
 
 #include "Application.h"
 #include "TVPSysFont.h"
@@ -1043,7 +1044,7 @@ bool TTVPWindowForm::OnCloseQuery() {
 		iTJSDispatch2 * obj = TJSNativeInstance->GetOwnerNoAddRef();
 		if(obj) {
 			tTJSVariant arg[1] = {true};
-			static ttstr eventname(TJS_W("onCloseQuery"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onCloseQuery")));
 
 			if(!ProgramClosing) {
 				// close action does not happen immediately

--- a/sound/SoundBufferBaseIntf.cpp
+++ b/sound/SoundBufferBaseIntf.cpp
@@ -13,6 +13,7 @@
 #include "SoundBufferBaseIntf.h"
 #include "MsgIntf.h"
 #include "EventIntf.h"
+#include "tjsGlobalStringMap.h"
 
 
 //---------------------------------------------------------------------------
@@ -56,10 +57,10 @@ void TJS_INTF_METHOD tTJSNI_BaseSoundBuffer::Invalidate()
 //---------------------------------------------------------------------------
 ttstr tTJSNI_BaseSoundBuffer::GetStatusString() const
 {
-	static ttstr unload(TJS_W("unload"));
-	static ttstr play(TJS_W("play"));
-	static ttstr stop(TJS_W("stop"));
-	static ttstr unknown(TJS_W("unknown"));
+	static ttstr unload(TJSMapGlobalStringMap(TJS_W("unload")));
+	static ttstr play(TJSMapGlobalStringMap(TJS_W("play")));
+	static ttstr stop(TJSMapGlobalStringMap(TJS_W("stop")));
+	static ttstr unknown(TJSMapGlobalStringMap(TJS_W("unknown")));
 
 	switch(Status)
 	{
@@ -86,7 +87,7 @@ void tTJSNI_BaseSoundBuffer::SetStatus(tTVPSoundStatus s)
 			{
 				// fire onStatusChanged event
 				tTJSVariant param(GetStatusString());
-				static ttstr eventname(TJS_W("onStatusChanged"));
+				static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onStatusChanged")));
 				TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE,
 					1, &param);
 			}
@@ -109,7 +110,7 @@ void tTJSNI_BaseSoundBuffer::SetStatusAsync(tTVPSoundStatus s)
 			if(Owner)
 			{
 				tTJSVariant param(GetStatusString());
-				static ttstr eventname(TJS_W("onStatusChanged"));
+				static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onStatusChanged")));
 				TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_POST,
 					1, &param);
 			}
@@ -187,7 +188,7 @@ void tTJSNI_BaseSoundBuffer::StopFade(bool async, bool settargetvol)
 		// post "onFadeCompleted" event to the owner
 		if(CanDeliverEvents)
 		{
-			static ttstr eventname(TJS_W("onFadeCompleted"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onFadeCompleted")));
 			TVPPostEvent(Owner, Owner, eventname, 0,
 				async?TVP_EPT_POST:TVP_EPT_IMMEDIATE, 0, NULL);
 		}

--- a/sound/WaveIntf.cpp
+++ b/sound/WaveIntf.cpp
@@ -890,7 +890,8 @@ void tTJSNI_BaseWaveSoundBuffer::RebuildFilterChain()
 	// get filter count
 	tTJSVariant v;
 	tjs_int count = 0;
-	Filters->PropGet(0, TJS_W("count"), NULL, &v, Filters);
+	static ttstr count_name(TJSMapGlobalStringMap(TJS_W("count")));
+	Filters->PropGet(0, count_name.c_str(), count_name.GetHint(), &v, Filters);
 	count = v;
 
 	// reset filter output
@@ -904,7 +905,8 @@ void tTJSNI_BaseWaveSoundBuffer::RebuildFilterChain()
 		// get iTVPBasicWaveFilter interface
 		tTJSVariantClosure clo = v.AsObjectClosureNoAddRef();
 		tTJSVariant iface_v;
-		if(TJS_FAILED(clo.PropGet(0, TJS_W("interface"), NULL, &iface_v, NULL))) continue;
+		static ttstr interface_name(TJSMapGlobalStringMap(TJS_W("interface")));
+		if(TJS_FAILED(clo.PropGet(0, interface_name.c_str(), interface_name.GetHint(), &iface_v, NULL))) continue;
 		iTVPBasicWaveFilter * filter =
 			reinterpret_cast<iTVPBasicWaveFilter *>((tjs_intptr_t)(tjs_int64)iface_v);
 		// save to the backupped array
@@ -996,11 +998,14 @@ iTJSDispatch2 * tTJSNI_BaseWaveSoundBuffer::GetWaveLabelsObjectNoAddRef()
 			{
 				tTJSVariant val;
 				val = i->Name.c_str(); // c_str() to avoid race condition for ttstr
-				item_dic->PropSet(TJS_MEMBERENSURE, TJS_W("name"), NULL, &val, item_dic);
+				static ttstr name_name(TJSMapGlobalStringMap(TJS_W("name")));
+				item_dic->PropSet(TJS_MEMBERENSURE, name_name.c_str(), name_name.GetHint(), &val, item_dic);
 				val = i->Position;
-				item_dic->PropSet(TJS_MEMBERENSURE, TJS_W("samplePosition"), NULL, &val, item_dic);
+				static ttstr samplePosition_name(TJSMapGlobalStringMap(TJS_W("samplePosition")));
+				item_dic->PropSet(TJS_MEMBERENSURE, samplePosition_name.c_str(), samplePosition_name.GetHint(), &val, item_dic);
 				val = freq ? i->Position * 1000 / freq : 0;
-				item_dic->PropSet(TJS_MEMBERENSURE, TJS_W("position"), NULL, &val, item_dic);
+				static ttstr position_name(TJSMapGlobalStringMap(TJS_W("position")));
+				item_dic->PropSet(TJS_MEMBERENSURE, position_name.c_str(), position_name.GetHint(), &val, item_dic);
 
 				tTJSVariant item_dic_var(item_dic, item_dic);
 

--- a/sound/WaveIntf.cpp
+++ b/sound/WaveIntf.cpp
@@ -18,6 +18,7 @@
 #include "UtilStreams.h"
 #include "WaveLoopManager.h"
 #include "tjsDictionary.h"
+#include "tjsGlobalStringMap.h"
 
 
 
@@ -864,7 +865,7 @@ void tTJSNI_BaseWaveSoundBuffer::InvokeLabelEvent(const ttstr & name)
 	if(Owner && CanDeliverEvents)
 	{
 		tTJSVariant param(name);
-		static ttstr eventname(TJS_W("onLabel"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onLabel")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_POST,
 			1, &param);
 	}

--- a/tjs2/tjs.cpp
+++ b/tjs2/tjs.cpp
@@ -151,19 +151,22 @@ tTJS::tTJS()
 		dsp = new tTJSArrayClass(); //TJSCreateArrayClass();
 		val = tTJSVariant(dsp, NULL);
 		dsp->Release();
-		Global->PropSet(TJS_MEMBERENSURE, TJS_W("Array"), NULL, &val, Global);
+		static ttstr Array_name(TJSMapGlobalStringMap(TJS_W("Array")));
+		Global->PropSet(TJS_MEMBERENSURE, Array_name.c_str(), Array_name.GetHint(), &val, Global);
 
 		// Dictionary
 		dsp = new tTJSDictionaryClass();
 		val = tTJSVariant(dsp, NULL);
 		dsp->Release();
-		Global->PropSet(TJS_MEMBERENSURE, TJS_W("Dictionary"), NULL, &val, Global);
+		static ttstr Dictionary_name(TJSMapGlobalStringMap(TJS_W("Dictionary")));
+		Global->PropSet(TJS_MEMBERENSURE, Dictionary_name.c_str(), Dictionary_name.GetHint(), &val, Global);
 
 		// Date
 		dsp = new tTJSNC_Date();
 		val = tTJSVariant(dsp, NULL);
 		dsp->Release();
-		Global->PropSet(TJS_MEMBERENSURE, TJS_W("Date"), NULL, &val, Global);
+		static ttstr Date_name(TJSMapGlobalStringMap(TJS_W("Date")));
+		Global->PropSet(TJS_MEMBERENSURE, Date_name.c_str(), Date_name.GetHint(), &val, Global);
 
 		// Math
 		{
@@ -172,26 +175,30 @@ tTJS::tTJS()
 			dsp = math = new tTJSNC_Math();
 			val = tTJSVariant(dsp, NULL);
 			dsp->Release();
-			Global->PropSet(TJS_MEMBERENSURE, TJS_W("Math"), NULL, &val, Global);
+			static ttstr Math_name(TJSMapGlobalStringMap(TJS_W("Math")));
+			Global->PropSet(TJS_MEMBERENSURE, Math_name.c_str(), Math_name.GetHint(), &val, Global);
 
 			// Math.RandomGenerator
 			dsp = new tTJSNC_RandomGenerator();
 			val = tTJSVariant(dsp, NULL);
 			dsp->Release();
-			math->PropSet(TJS_MEMBERENSURE, TJS_W("RandomGenerator"), NULL, &val, math);
+			static ttstr RandomGenerator_name(TJSMapGlobalStringMap(TJS_W("RandomGenerator")));
+			math->PropSet(TJS_MEMBERENSURE, RandomGenerator_name.c_str(), RandomGenerator_name.GetHint(), &val, math);
 		}
 
 		// Exception
 		dsp = new tTJSNC_Exception();
 		val = tTJSVariant(dsp, NULL);
 		dsp->Release();
-		Global->PropSet(TJS_MEMBERENSURE, TJS_W("Exception"), NULL, &val, Global);
+		static ttstr Exception_name(TJSMapGlobalStringMap(TJS_W("Exception")));
+		Global->PropSet(TJS_MEMBERENSURE, Exception_name.c_str(), Exception_name.GetHint(), &val, Global);
 #ifndef TJS_NO_REGEXP
 		// RegExp
 		dsp = TJSCreateRegExpClass(); // the body is implemented in tjsRegExp.cpp
 		val = tTJSVariant(dsp, NULL);
 		dsp->Release();
-		Global->PropSet(TJS_MEMBERENSURE, TJS_W("RegExp"), NULL, &val, Global);
+		static ttstr RegExp_name(TJSMapGlobalStringMap(TJS_W("RegExp")));
+		Global->PropSet(TJS_MEMBERENSURE, RegExp_name.c_str(), RegExp_name.GetHint(), &val, Global);
 #endif
 	}
 	catch(...)

--- a/tjs2/tjsArray.cpp
+++ b/tjs2/tjsArray.cpp
@@ -19,6 +19,7 @@
 #include "tjsUtils.h"
 #include "tjsBinarySerializer.h"
 #include "tjsOctPack.h"
+#include "tjsGlobalStringMap.h"
 
 #ifndef TJS_NO_REGEXP
 #include "tjsRegExp.h"
@@ -408,9 +409,9 @@ TJS_BEGIN_NATIVE_METHOD_DECL(/* func. name */save)
 	{
 		tTJSArrayNI::tArrayItemIterator i = ni->Items.begin();
 #ifdef TJS_TEXT_OUT_CRLF
-		const static ttstr cr(TJS_W("\r\n"));
+		const static ttstr cr(TJSMapGlobalStringMap(TJS_W("\r\n")));
 #else
-		const static ttstr cr(TJS_W("\n"));
+		const static ttstr cr(TJSMapGlobalStringMap(TJS_W("\n")));
 #endif
 
 		while( i != ni->Items.end())

--- a/tjs2/tjsByteCodeLoader.cpp
+++ b/tjs2/tjsByteCodeLoader.cpp
@@ -338,7 +338,7 @@ void tTJSByteCodeLoader::ReadObjects( tTJSScriptBlock* block, const tjs_uint8* b
 				int pobj = prop[pos+1];
 				// register members to the parent object
 				val = objs[pobj];
-				obj->PropSet( TJS_MEMBERENSURE|TJS_IGNOREPROP, StringArray[pname].c_str(), NULL, &val, obj );
+				obj->PropSet( TJS_MEMBERENSURE|TJS_IGNOREPROP, StringArray[pname].c_str(), StringArray[pname].GetHint(), &val, obj );
 			}
 		}
 	}

--- a/tjs2/tjsConfig.cpp
+++ b/tjs2/tjsConfig.cpp
@@ -136,6 +136,8 @@ tjs_char * TJS_tTVInt_to_str(tjs_int64 value, tjs_char *string)
 tjs_int TJS_strnicmp(const tjs_char *s1, const tjs_char *s2,
 	size_t maxlen)
 {
+	if (s1 == s2) return 0;
+
 	while(maxlen--)
 	{
 		tjs_char c1 = *s1, c2 = *s2;
@@ -156,6 +158,8 @@ tjs_int TJS_stricmp(const tjs_char *s1, const tjs_char *s2)
 {
 	// we only support basic alphabets
 	// fixme: complete alphabets support
+
+	if (s1 == s2) return 0;
 
 	for(;;)
 	{
@@ -331,6 +335,8 @@ tjs_char * TJS_strstr(const tjs_char *big, const tjs_char *little)
 //---------------------------------------------------------------------------
 tjs_int TJS_strcmp(const tjs_char *s1, const tjs_char *s2)
 {
+	if (s1 == s2) return 0;
+
 	while (*s1 == *s2++)
 		if (*s1++ == '\0')
 			return (0);
@@ -339,6 +345,8 @@ tjs_int TJS_strcmp(const tjs_char *s1, const tjs_char *s2)
 //---------------------------------------------------------------------------
 tjs_int TJS_strncmp(const tjs_char *s1, const tjs_char *s2, size_t n)
 {
+	if (s1 == s2) return 0;
+
 	if (n == 0)
 		return (0);
 	do {

--- a/tjs2/tjsDebug.cpp
+++ b/tjs2/tjsDebug.cpp
@@ -449,7 +449,7 @@ void TJSAddObjectHashRecord(void * object)
 	if(where.IsEmpty())
 		where = TJSMapGlobalStringMap((const tjs_char *)TJSCallHistoryIsFromOutOfTJS2Script);
 	rec.Where = where;
-	static ttstr InitialType(TJS_W("unknown type"));
+	static ttstr InitialType(TJSMapGlobalStringMap(TJS_W("unknown type")));
 	rec.Type = InitialType;
 
 	if(TJSObjectHashMap)

--- a/tjs2/tjsDictionary.cpp
+++ b/tjs2/tjsDictionary.cpp
@@ -389,7 +389,7 @@ TJS_BEGIN_NATIVE_METHOD_DECL(/*func.name*/contains ) {
 		if( param[0]->Type() != tvtString ) return TJS_E_INVALIDPARAM;
 		if( result ) {
 			tTJSVariant tmp;
-			if( TJS_SUCCEEDED( objthis->PropGet( TJS_MEMBERMUSTEXIST, *( param[1]->AsStringNoAddRef() ), nullptr, &tmp, objthis ) ) ) {
+			if( TJS_SUCCEEDED( objthis->PropGet( TJS_MEMBERMUSTEXIST, param[1]->GetString(), param[1]->GetHint(), &tmp, objthis ) ) ) {
 				*result = (tjs_int)1;
 			} else {
 				*result = (tjs_int)0;
@@ -404,7 +404,7 @@ TJS_BEGIN_NATIVE_METHOD_DECL(/*func.name*/contains ) {
 	if( param[1]->Type() != tvtString ) return TJS_E_INVALIDPARAM;
 	if( result ) {
 		tTJSVariant tmp;
-		if( TJS_SUCCEEDED( disp->PropGet( TJS_MEMBERMUSTEXIST, *(param[1]->AsStringNoAddRef()), nullptr, &tmp, disp ) ) ) {
+		if( TJS_SUCCEEDED( disp->PropGet( TJS_MEMBERMUSTEXIST, param[1]->GetString(), param[1]->GetHint(), &tmp, disp ) ) ) {
 			*result = (tjs_int)1;
 		} else {
 			*result = (tjs_int)0;

--- a/tjs2/tjsError.cpp
+++ b/tjs2/tjsError.cpp
@@ -14,6 +14,7 @@
 #include "tjsScriptBlock.h"
 #include "tjsError.h"
 #include "tjs.h"
+#include "tjsGlobalStringMap.h"
 
 #define TJS_MAX_TRACE_TEXT_LEN 1500
 
@@ -31,7 +32,7 @@ void TJSGetExceptionObject(tTJS *tjs, tTJSVariant *res, tTJSVariant &msg,
 	// retrieve class "Exception" from global
 	iTJSDispatch2 *global = tjs->GetGlobalNoAddRef();
 	tTJSVariant val;
-	static tTJSString Exception_name(TJS_W("Exception"));
+	static tTJSString Exception_name(TJSMapGlobalStringMap(TJS_W("Exception")));
 	tjs_error hr = global->PropGet(0, Exception_name.c_str(),
 		Exception_name.GetHint(), &val, global);
 	if(TJS_FAILED(hr)) TJS_eTJSError(TJSExceptionNotFound);
@@ -43,7 +44,7 @@ void TJSGetExceptionObject(tTJS *tjs, tTJSVariant *res, tTJSVariant &msg,
 	if(TJS_FAILED(hr)) TJS_eTJSError(TJSExceptionNotFound);
 	if(trace)
 	{
-		static tTJSString trace_name(TJS_W("trace"));
+		static tTJSString trace_name(TJSMapGlobalStringMap(TJS_W("trace")));
 		excpobj->PropSet(TJS_MEMBERENSURE, trace_name.c_str(), trace_name.GetHint(),
 			trace, excpobj);
 	}

--- a/tjs2/tjsException.cpp
+++ b/tjs2/tjsException.cpp
@@ -11,6 +11,7 @@
 #include "tjsCommHead.h"
 
 #include "tjsException.h"
+#include "tjsGlobalStringMap.h"
 
 namespace TJS
 {
@@ -34,13 +35,13 @@ TJS_BEGIN_NATIVE_CONSTRUCTOR_DECL_NO_INSTANCE(/*TJS class name*/Exception)
 	tTJSVariant val = TJS_W("");
 	if(TJS_PARAM_EXIST(0)) val.CopyRef(*param[0]);
 
-	static tTJSString message_name(TJS_W("message"));
+	static tTJSString message_name(TJSMapGlobalStringMap(TJS_W("message")));
 	objthis->PropSet(TJS_MEMBERENSURE, message_name.c_str(), message_name.GetHint(),
 		&val, objthis);
 
 	if(TJS_PARAM_EXIST(1)) val.CopyRef(*param[1]); else val = TJS_W("");
 
-	static tTJSString trace_name(TJS_W("trace"));
+	static tTJSString trace_name(TJSMapGlobalStringMap(TJS_W("trace")));
 	objthis->PropSet(TJS_MEMBERENSURE, trace_name.c_str(), trace_name.GetHint(),
 		&val, objthis);
 

--- a/tjs2/tjsInterCodeExec.cpp
+++ b/tjs2/tjsInterCodeExec.cpp
@@ -21,6 +21,7 @@
 #include "tjsArray.h"
 #include "tjsDebug.h"
 #include "tjsOctPack.h"
+#include "tjsGlobalStringMap.h"
 
 #ifdef ENABLE_DEBUGGER
 #include "debugger.h"
@@ -994,7 +995,7 @@ void tTJSInterCodeContext::ThrowScriptException(tTJSVariant &val,
 			if(clo.Object != NULL)
 			{
 				tTJSVariant v2;
-				static tTJSString message_name(TJS_W("message"));
+				static tTJSString message_name(TJSMapGlobalStringMap(TJS_W("message")));
 				tjs_error hr = clo.PropGet(0, message_name.c_str(),
 					message_name.GetHint(), &v2, NULL);
 				if(TJS_SUCCEEDED(hr))
@@ -2752,7 +2753,7 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		tTJSVariantClosure clo = args[0]->AsObjectClosureNoAddRef();
 		tTJSVariant str = target;
 		tTJSVariant *params[] = { &str, args[1] };
-		static tTJSString replace_name(TJS_W("replace"));
+		static tTJSString replace_name(TJSMapGlobalStringMap(TJS_W("replace")));
 		clo.FuncCall(0, replace_name.c_str(), replace_name.GetHint(),
 			result, 2, params, NULL);
 
@@ -2789,7 +2790,7 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 				arg_count ++;
 				params[3] = args[2];
 			}
-			static tTJSString split_name(TJS_W("split"));
+			static tTJSString split_name(TJSMapGlobalStringMap(TJS_W("split")));
 			array->FuncCall(0, split_name.c_str(), split_name.GetHint(),
 				NULL, arg_count, params, array);
 
@@ -2956,12 +2957,12 @@ void tTJSInterCodeContext::ProcessOctetFunction(const tjs_char *member, const tT
 void tTJSInterCodeContext::TypeOf(tTJSVariant &val)
 {
 	// processes TJS2's typeof operator.
-	static tTJSString void_name(TJS_W("void"));
-	static tTJSString Object_name(TJS_W("Object"));
-	static tTJSString String_name(TJS_W("String"));
-	static tTJSString Integer_name(TJS_W("Integer"));
-	static tTJSString Real_name(TJS_W("Real"));
-	static tTJSString Octet_name(TJS_W("Octet"));
+	static tTJSString void_name(TJSMapGlobalStringMap(TJS_W("void")));
+	static tTJSString Object_name(TJSMapGlobalStringMap(TJS_W("Object")));
+	static tTJSString String_name(TJSMapGlobalStringMap(TJS_W("String")));
+	static tTJSString Integer_name(TJSMapGlobalStringMap(TJS_W("Integer")));
+	static tTJSString Real_name(TJSMapGlobalStringMap(TJS_W("Real")));
+	static tTJSString Octet_name(TJSMapGlobalStringMap(TJS_W("Octet")));
 
 	switch(val.Type())
 	{

--- a/tjs2/tjsInterCodeExec.cpp
+++ b/tjs2/tjsInterCodeExec.cpp
@@ -1716,7 +1716,7 @@ void tTJSInterCodeContext::GetPropertyIndirect(tTJSVariant *ra,
 		try
 		{
 			// TODO: verify here needs hint holding
-			hr = clo.PropGet(flags, *str, NULL, TJS_GET_VM_REG_ADDR(ra, code[1]),
+			hr = clo.PropGet(flags, *str, str->GetHint(), TJS_GET_VM_REG_ADDR(ra, code[1]),
 				clo.ObjThis?clo.ObjThis:ra[-1].AsObjectNoAddRef());
 			if(TJS_FAILED(hr)) TJSThrowFrom_tjs_error(hr, *str);
 		}
@@ -1779,7 +1779,7 @@ void tTJSInterCodeContext::SetPropertyIndirect(tTJSVariant *ra,
 					clo.ObjThis?clo.ObjThis:ra[-1].AsObjectNoAddRef());
 			if(hr == TJS_E_NOTIMPL)
 				hr = clo.PropSet(flags,
-					*str, NULL, TJS_GET_VM_REG_ADDR(ra, code[3]),
+					*str, str->GetHint(), TJS_GET_VM_REG_ADDR(ra, code[3]),
 						clo.ObjThis?clo.ObjThis:ra[-1].AsObjectNoAddRef());
 			if(TJS_FAILED(hr)) TJSThrowFrom_tjs_error(hr, *str);
 		}
@@ -1862,7 +1862,7 @@ void tTJSInterCodeContext::OperatePropertyIndirect(tTJSVariant *ra,
 		tjs_error hr;
 		try
 		{
-			hr = clo.Operation(ope, *str, NULL,
+			hr = clo.Operation(ope, *str, str->GetHint(),
 				code[1]?TJS_GET_VM_REG_ADDR(ra, code[1]):NULL,
 				TJS_GET_VM_REG_ADDR(ra, code[4]),
 					clo.ObjThis?clo.ObjThis:ra[-1].AsObjectNoAddRef());
@@ -1970,7 +1970,7 @@ void tTJSInterCodeContext::OperatePropertyIndirect0(tTJSVariant *ra,
 		tjs_error hr;
 		try
 		{
-			hr = clo.Operation(ope, *str, NULL,
+			hr = clo.Operation(ope, *str, str->GetHint(),
 				code[1]?TJS_GET_VM_REG_ADDR(ra, code[1]):NULL, NULL,
 					clo.ObjThis?clo.ObjThis:ra[-1].AsObjectNoAddRef());
 			if(TJS_FAILED(hr)) TJSThrowFrom_tjs_error(hr, *str);
@@ -2076,7 +2076,7 @@ void tTJSInterCodeContext::DeleteMemberIndirect(tTJSVariant *ra,
 
 	try
 	{
-		hr = clo.DeleteMember(0, *str, NULL,
+		hr = clo.DeleteMember(0, *str, str->GetHint(),
 			clo.ObjThis?clo.ObjThis:ra[-1].AsObjectNoAddRef());
 		if(code[1])
 		{
@@ -2186,7 +2186,7 @@ void tTJSInterCodeContext::TypeOfMemberIndirect(tTJSVariant *ra,
 		try
 		{
 			// TODO: verify here needs hint holding
-			hr = clo.PropGet(flags, *str, NULL, TJS_GET_VM_REG_ADDR(ra, code[1]),
+			hr = clo.PropGet(flags, *str, str->GetHint(), TJS_GET_VM_REG_ADDR(ra, code[1]),
 				clo.ObjThis?clo.ObjThis:ra[-1].AsObjectNoAddRef());
 			if(hr == TJS_S_OK)
 			{
@@ -3073,7 +3073,7 @@ void tTJSInterCodeContext::InMember( tTJSVariant &name, tTJSVariant &obj ) {
 		try
 		{
 			tTJSVariant tmp;
-			hr = obj.AsObjectClosureNoAddRef().PropGet( TJS_MEMBERMUSTEXIST, *str, nullptr, &tmp, obj.AsObjectThisNoAddRef() );
+			hr = obj.AsObjectClosureNoAddRef().PropGet( TJS_MEMBERMUSTEXIST, *str, str->GetHint(), &tmp, obj.AsObjectThisNoAddRef() );
 		}
 		catch(...)
 		{
@@ -3124,7 +3124,7 @@ void tTJSInterCodeContext::RegisterObjectMember(iTJSDispatch2 * dest)
 				if(Dest->PropSetByVS(TJS_MEMBERENSURE|TJS_IGNOREPROP|flags,
 					param[0]->AsStringNoAddRef(), &val, Dest) == TJS_E_NOTIMPL)
 					Dest->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP|flags,
-					param[0]->GetString(), NULL, &val, Dest);
+					param[0]->GetString(), param[0]->GetHint(), &val, Dest);
 			}
 			if(result) *result = (tjs_int)(1); // returns true
 			return TJS_S_OK;

--- a/tjs2/tjsInterCodeExec.cpp
+++ b/tjs2/tjsInterCodeExec.cpp
@@ -53,7 +53,8 @@ static void GetStringProperty(tTJSVariant *result, const tTJSVariant *str,
 		const tjs_char *name = member.GetString();
 		if(!name) TJSThrowFrom_tjs_error(TJS_E_MEMBERNOTFOUND, TJS_W(""));
 
-		if(!TJS_strcmp(name, TJS_W("length")))
+		static ttstr length_name(TJSMapGlobalStringMap(TJS_W("length")));
+		if(length_name == name)
 		{
 			// get string length
 			const tTJSVariantString * s = str->AsStringNoAddRef();
@@ -109,7 +110,8 @@ static void SetStringProperty(tTJSVariant *param, const tTJSVariant *str,
 		const tjs_char *name = member.GetString();
 		if(!name) TJSThrowFrom_tjs_error(TJS_E_MEMBERNOTFOUND, TJS_W(""));
 
-		if(!TJS_strcmp(name, TJS_W("length")))
+		static ttstr length_name(TJSMapGlobalStringMap(TJS_W("length")));
+		if(length_name == name)
 		{
 			TJSThrowFrom_tjs_error(TJS_E_ACCESSDENYED, TJS_W(""));
 		}
@@ -135,7 +137,8 @@ static void GetOctetProperty(tTJSVariant *result, const tTJSVariant *octet,
 		const tjs_char *name = member.GetString();
 		if(!name) TJSThrowFrom_tjs_error(TJS_E_MEMBERNOTFOUND, TJS_W(""));
 
-		if(!TJS_strcmp(name, TJS_W("length")))
+		static ttstr length_name(TJSMapGlobalStringMap(TJS_W("length")));
+		if(length_name == name)
 		{
 			// get string length
 			tTJSVariantOctet *o = octet->AsOctetNoAddRef();
@@ -179,7 +182,8 @@ static void SetOctetProperty(tTJSVariant *param, const tTJSVariant *octet,
 		const tjs_char *name = member.GetString();
 		if(!name) TJSThrowFrom_tjs_error(TJS_E_MEMBERNOTFOUND, TJS_W(""));
 
-		if(!TJS_strcmp(name, TJS_W("length")))
+		static ttstr length_name(TJSMapGlobalStringMap(TJS_W("length")));
+		if(length_name == name)
 		{
 			TJSThrowFrom_tjs_error(TJS_E_ACCESSDENYED, TJS_W(""));
 		}
@@ -2526,80 +2530,17 @@ void tTJSInterCodeContext::AddClassInstanceInfo(tTJSVariant *ra,
 	}
 }
 //---------------------------------------------------------------------------
-static const tjs_char * const StrFuncs[] =
-{ 
-	TJS_W("charAt"), 
-	TJS_W("indexOf"), 
-	TJS_W("toUpperCase"),
-	TJS_W("toLowerCase"), 
-	TJS_W("substring"), 
-	TJS_W("substr"), 
-	TJS_W("sprintf"),
-	TJS_W("replace"), 
-	TJS_W("escape"), 
-	TJS_W("split"),
-	TJS_W("trim"),
-	TJS_W("reverse"),
-	TJS_W("repeat"),
-	TJS_W("startsWith"),
-	TJS_W("endsWith"),
-	TJS_W("parseNumber")
-};
-
-enum tTJSStringMethodNameIndex
-{
-	TJSStrMethod_charAt = 0,
-	TJSStrMethod_indexOf,
-	TJSStrMethod_toUpperCase,
-	TJSStrMethod_toLowerCase,
-	TJSStrMethod_substring, 
-	TJSStrMethod_substr, 
-	TJSStrMethod_sprintf,
-	TJSStrMethod_replace, 
-	TJSStrMethod_escape, 
-	TJSStrMethod_split,
-	TJSStrMethod_trim,
-	TJSStrMethod_reverse,
-	TJSStrMethod_repeat,
-	TJSStrMethod_startsWith,
-	TJSStrMethod_endsWith,
-	TJSStrMethod_parseNumber
-};
-
-#define TJS_STRFUNC_MAX (sizeof(StrFuncs) / sizeof(StrFuncs[0]))
-static tjs_int32 StrFuncHash[TJS_STRFUNC_MAX];
-static bool TJSStrFuncInit = false;
-static void InitTJSStrFunc()
-{
-	TJSStrFuncInit = true;
-	for(tjs_int i=0; i<TJS_STRFUNC_MAX; i++)
-	{
-		const tjs_char *p = StrFuncs[i];
-		tjs_int32 hash = 0;
-		while(*p) hash += *p, p++;
-		StrFuncHash[i] = hash;
-	}
-}
 
 void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 	const ttstr & target, tTJSVariant **args, tjs_int numargs, tTJSVariant *result)
 {
-	if(!TJSStrFuncInit) InitTJSStrFunc();
-
-	tjs_int32 hash;
-
 	if(!member) TJSThrowFrom_tjs_error(TJS_E_MEMBERNOTFOUND, TJS_W(""));
-
-	const tjs_char *m = member;
-	hash = 0;
-	while(*m) hash += *m, m++;
 
 	const tjs_char *s = target.c_str(); // target string
 	const tjs_int s_len = target.GetLen();
 
-#define TJS_STR_METHOD_IS(_name) (hash == StrFuncHash[TJSStrMethod_##_name] && !TJS_strcmp(StrFuncs[TJSStrMethod_##_name], member))
-
-	if(TJS_STR_METHOD_IS(charAt))
+	static ttstr charAt_name(TJSMapGlobalStringMap(TJS_W("charAt")));
+	if(charAt_name == member)
 	{
 		if(numargs != 1) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
 		if(s_len == 0)
@@ -2619,7 +2560,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		if(result) *result = bt;
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(indexOf))
+	static ttstr indexOf_name(TJSMapGlobalStringMap(TJS_W("indexOf")));
+	if(indexOf_name == member)
 	{
 		if(numargs != 1 && numargs != 2) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
 		tTJSVariantString *pstr = args[0]->AsString(); // sub string
@@ -2666,7 +2608,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		if(pstr) pstr->Release();
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(toUpperCase))
+	static ttstr toUpperCase_name(TJSMapGlobalStringMap(TJS_W("toUpperCase")));
+	if(toUpperCase == member)
 	{
 		if(numargs != 0) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
 		if(result)
@@ -2685,7 +2628,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		}
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(toLowerCase))
+	static ttstr toLowerCase_name(TJSMapGlobalStringMap(TJS_W("toLowerCase")));
+	if(toLowerCase_name == member)
 	{
 		if(numargs != 0) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
 		if(result)
@@ -2704,7 +2648,9 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		}
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(substring) || TJS_STR_METHOD_IS(substr))
+	static ttstr substring_name(TJSMapGlobalStringMap(TJS_W("substring")));
+	static ttstr substr_name(TJSMapGlobalStringMap(TJS_W("substr")));
+	if(substring_name == member || substr_name == member)
 	{
 		if(numargs != 1 && numargs != 2) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
 		tjs_int start = (tjs_int)*args[0];
@@ -2733,7 +2679,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		}
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(sprintf))
+	static ttstr sprintf_name(TJSMapGlobalStringMap(TJS_W("sprintf")));
+	if(sprintf_name == member)
 	{
 		if(result)
 		{
@@ -2744,7 +2691,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		}
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(replace))
+	static ttstr replace__name(TJSMapGlobalStringMap(TJS_W("replace")));
+	if(replace__name == member)
 	{
 		// string.replace(pattern, replacement-string)  -->
 		// pattern.replace(string, replacement-string)
@@ -2759,14 +2707,16 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(escape))
+	static ttstr escape_name(TJSMapGlobalStringMap(TJS_W("escape")));
+	if(escape_name == member)
 	{
 		if(result)
 			*result = target.EscapeC();
 
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(split))
+	static ttstr split_name(TJSMapGlobalStringMap(TJS_W("split")));
+	if(split_name == member)
 	{
 		// string.split(pattern, reserved, purgeempty) -->
 		// Array.split(pattern, string, reserved, purgeempty)
@@ -2805,7 +2755,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(trim))
+	static ttstr trim_name(TJSMapGlobalStringMap(TJS_W("trim")));
+	if(trim_name == member)
 	{
 		if(numargs != 0) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
 		if(!result) return;
@@ -2829,7 +2780,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		*result = tTJSString(src, w_len);
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(reverse))
+	static ttstr reverse_name(TJSMapGlobalStringMap(TJS_W("reverse")));
+	if(reverse_name == member)
 	{
 		if(numargs != 0) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
  		if(!result) return;
@@ -2851,7 +2803,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		}
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(repeat))
+	static ttstr repeat_name(TJSMapGlobalStringMap(TJS_W("repeat")));
+	if(repeat_name == member)
 	{
 		if(numargs != 1) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
 		if(!result) return;
@@ -2875,14 +2828,16 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(startsWith))
+	static ttstr startsWith_name(TJSMapGlobalStringMap(TJS_W("startsWith")));
+	if(startsWith_name == member)
 	{
 		if(numargs != 1) TJSThrowFrom_tjs_error( TJS_E_BADPARAMCOUNT );
 		if(!result) return;
 		*result = target.StartsWith( args[0]->AsStringNoAddRef() ) ? 1 : 0;
 		return;
 	}
-	else if(TJS_STR_METHOD_IS(endsWith))
+	static ttstr endsWith_name(TJSMapGlobalStringMap(TJS_W("endsWith")));
+	if(endsWith_name == member)
 	{
 		if( numargs != 1 ) TJSThrowFrom_tjs_error( TJS_E_BADPARAMCOUNT );
 		if( !result ) return;
@@ -2909,7 +2864,8 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		}
 		return;
 	}
-	else if (TJS_STR_METHOD_IS(parseNumber))
+	static ttstr parseNumber_name(TJSMapGlobalStringMap(TJS_W("parseNumber")));
+	if (parseNumber_name == member)
 	{
 		if (!result) return;
 		// if (numargs != 1) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT); // 現在基数指定は未対応
@@ -2922,7 +2878,6 @@ void tTJSInterCodeContext::ProcessStringFunction(const tjs_char *member,
 		return;
 	}
 
-#undef TJS_STR_METHOD_IS
 
 	TJSThrowFrom_tjs_error(TJS_E_MEMBERNOTFOUND, member);
 }
@@ -2931,25 +2886,21 @@ void tTJSInterCodeContext::ProcessOctetFunction(const tjs_char *member, const tT
 		tTJSVariant **args, tjs_int numargs, tTJSVariant *result)
 {
 	if(!member) TJSThrowFrom_tjs_error(TJS_E_MEMBERNOTFOUND, TJS_W(""));
-	switch( member[0] ) {
-	case TJS_W('u'):
-		if( !TJS_strcmp( TJS_W("unpack"), member) ) {
-			tjs_error err = TJSOctetUnpack( target, args, numargs, result );
-			if( err != TJS_S_OK ) {
-				TJSThrowFrom_tjs_error( err );
-			}
-			return;
+	static ttstr unpack_name(TJSMapGlobalStringMap(TJS_W("unpack")));
+	if( unpack_name == member ) {
+		tjs_error err = TJSOctetUnpack( target, args, numargs, result );
+		if( err != TJS_S_OK ) {
+			TJSThrowFrom_tjs_error( err );
 		}
-		break;
-#if 0
-	case TJS_W('p'):
-		if( !TJS_strcmp( TJS_W("pack"), member) ) {
-			if(numargs < 2) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
-			ttstr templ = *args[0];
-		}
-		break;
-#endif
+		return;
 	}
+#if 0
+	static ttstr pack_name(TJSMapGlobalStringMap(TJS_W("pack")));
+	if( pack_name == member ) {
+		if(numargs < 2) TJSThrowFrom_tjs_error(TJS_E_BADPARAMCOUNT);
+		ttstr templ = *args[0];
+	}
+#endif
 
 	TJSThrowFrom_tjs_error(TJS_E_MEMBERNOTFOUND, member);
 }
@@ -3360,15 +3311,18 @@ tjs_error TJS_INTF_METHOD  tTJSInterCodeContext::IsInstanceOf(tjs_uint32 flag,
 
 		case ctFunction:
 		case ctExprFunction:
-			if(!TJS_strcmp(classname, TJS_W("Function"))) return TJS_S_TRUE;
+			static ttstr Function_name(TJSMapGlobalStringMap(TJS_W("Function")));
+			if(Function_name == classname) return TJS_S_TRUE;
 			break;
 
 		case ctProperty:
-			if(!TJS_strcmp(classname, TJS_W("Property"))) return TJS_S_TRUE;
+			static ttstr Property_name(TJSMapGlobalStringMap(TJS_W("Property")));
+			if(Function_name == classname) return TJS_S_TRUE;
 			break;
 			
 		case ctClass:
-			if(!TJS_strcmp(classname, TJS_W("Class"))) return TJS_S_TRUE;
+			static ttstr Class_name(TJSMapGlobalStringMap(TJS_W("Class")));
+			if(Class_name == classname) return TJS_S_TRUE;
 			break;
 		}
 	}

--- a/tjs2/tjsInterCodeGen.cpp
+++ b/tjs2/tjsInterCodeGen.cpp
@@ -159,7 +159,7 @@ void tTJSExprNode::Add(tTJSExprNode *n)
 //---------------------------------------------------------------------------
 void tTJSExprNode::AddArrayElement(const tTJSVariant & val)
 {
-	static tTJSString ss_add(TJS_W("add"));
+	static tTJSString ss_add(TJSMapGlobalStringMap(TJS_W("add")));
 	tTJSVariant arg(val);
 	tTJSVariant *args[1] = {&arg};
 	Val->AsObjectClosureNoAddRef().FuncCall(0, ss_add.c_str(), ss_add.GetHint(),

--- a/tjs2/tjsNative.cpp
+++ b/tjs2/tjsNative.cpp
@@ -282,7 +282,7 @@ void tTJSNativeClass::RegisterNCM(const tjs_char *name, iTJSDispatch2 *dsp,
 	if(PropSetByVS((TJS_MEMBERENSURE | TJS_IGNOREPROP) | flags,
 		tname.AsVariantStringNoAddRef(), &val, this) == TJS_E_NOTIMPL)
 		PropSet((TJS_MEMBERENSURE | TJS_IGNOREPROP) | flags,
-			tname.c_str(), NULL, &val, this);
+			tname.c_str(), tname.GetHint(), &val, this);
 
 	// release dsp
 	dsp->Release();
@@ -357,7 +357,7 @@ tTJSNativeClass::FuncCall(tjs_uint32 flag, const tjs_char * membername,
 				if(Dest->PropSetByVS(TJS_MEMBERENSURE|TJS_IGNOREPROP|flags,
 					param[0]->AsStringNoAddRef(), &val, Dest) == TJS_E_NOTIMPL)
 					Dest->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP|flags,
-					param[0]->GetString(), NULL, &val, Dest);
+					param[0]->GetString(), param[0]->GetHint(), &val, Dest);
 			}
 			if(result) *result = (tjs_int)(1); // returns true
 			return TJS_S_OK;

--- a/tjs2/tjsNative.cpp
+++ b/tjs2/tjsNative.cpp
@@ -76,7 +76,8 @@ tTJSNativeClassMethod::IsInstanceOf(tjs_uint32 flag,
 {
 	if(membername == NULL)
 	{
-		if(!TJS_strcmp(classname, TJS_W("Function"))) return TJS_S_TRUE;
+		static ttstr Function_name(TJSMapGlobalStringMap(TJS_W("Function")));
+		if(Function_name == classname) return TJS_S_TRUE;
 	}
 
 	return inherited::IsInstanceOf(flag, membername, hint, classname, objthis);
@@ -170,7 +171,8 @@ tTJSNativeClassProperty::IsInstanceOf(tjs_uint32 flag,
 {
 	if(membername == NULL)
 	{
-		if(!TJS_strcmp(classname, TJS_W("Property"))) return TJS_S_TRUE;
+		static ttstr Property_name(TJSMapGlobalStringMap(TJS_W("Property")));
+		if(Property_name == classname) return TJS_S_TRUE;
 	}
 
 	return inherited::IsInstanceOf(flag, membername, hint, classname, objthis);
@@ -437,8 +439,9 @@ tTJSNativeClass::IsInstanceOf(tjs_uint32 flag,
 {
 	if(membername == NULL)
 	{
-		if(!TJS_strcmp(classname, TJS_W("Class"))) return TJS_S_TRUE;
-		if(!TJS_strcmp(classname, ClassName.c_str())) return TJS_S_TRUE;
+		static ttstr Class_name(TJSMapGlobalStringMap(TJS_W("Class")));
+		if(Class_name == classname) return TJS_S_TRUE;
+		if(ClassName == classname) return TJS_S_TRUE;
 	}
 
 	return inherited::IsInstanceOf(flag, membername, hint, classname, objthis);
@@ -482,7 +485,8 @@ tjs_error TJS_INTF_METHOD tTJSNativeFunction::IsInstanceOf(
 {
 	if(membername == NULL)
 	{
-		if(!TJS_strcmp(classname, TJS_W("Function"))) return TJS_S_TRUE;
+		static ttstr Function_name(TJSMapGlobalStringMap(TJS_W("Function")));
+		if(Function_name == classname) return TJS_S_TRUE;
 	}
 
 	return inherited::IsInstanceOf(flag, membername, hint, classname, objthis);

--- a/tjs2/tjsObject.cpp
+++ b/tjs2/tjsObject.cpp
@@ -1846,26 +1846,32 @@ tjs_error TJSDefaultIsInstanceOf(tjs_uint32 flag, tTJSVariant &targ, const tjs_c
 		return TJS_S_FALSE;
 	}
 
-	if(!TJS_strcmp(name, TJS_W("Object"))) return TJS_S_TRUE;
+	static ttstr Object_name(TJSMapGlobalStringMap(TJS_W("Object")));
+	if(Object_name == name) return TJS_S_TRUE;
 
 
+	static ttstr Integer_name(TJSMapGlobalStringMap(TJS_W("Integer")));
+	static ttstr Real_name(TJSMapGlobalStringMap(TJS_W("Real")));
+	static ttstr Number_name(TJSMapGlobalStringMap(TJS_W("Number")));
+	static ttstr String_name(TJSMapGlobalStringMap(TJS_W("String")));
+	static ttstr Octet_name(TJSMapGlobalStringMap(TJS_W("Octet")));
 	switch(vt)
 	{
 	case tvtVoid:
 		return TJS_S_FALSE; // returns always false about tvtVoid
 	case tvtInteger:
-		if(!TJS_strcmp(name, TJS_W("Integer"))) return TJS_S_TRUE;
-		if(!TJS_strcmp(name, TJS_W("Number"))) return TJS_S_TRUE;
+		if(Integer_name == name) return TJS_S_TRUE;
+		if(Number_name == name) return TJS_S_TRUE;
 		return TJS_S_FALSE;
 	case tvtReal:
-		if(!TJS_strcmp(name, TJS_W("Real"))) return TJS_S_TRUE;
-		if(!TJS_strcmp(name, TJS_W("Number"))) return TJS_S_TRUE;
+		if(Real_name == name) return TJS_S_TRUE;
+		if(Number_name == name) return TJS_S_TRUE;
 		return TJS_S_FALSE;
 	case tvtString:
-		if(!TJS_strcmp(name, TJS_W("String"))) return TJS_S_TRUE;
+		if(String_name == name) return TJS_S_TRUE;
 		return TJS_S_FALSE;
 	case tvtOctet:
-		if(!TJS_strcmp(name, TJS_W("Octet"))) return TJS_S_TRUE;
+		if(Octet_name == name) return TJS_S_TRUE;
 		return TJS_S_FALSE;
 	case tvtObject:
 		if(vt == tvtObject)
@@ -1895,18 +1901,13 @@ tTJSCustomObject::IsInstanceOf(tjs_uint32 flag, const tjs_char *membername, tjs_
 	if(membername == NULL)
 	{
 		// always returns true if "Object" is specified
-		if(!TJS_strcmp(classname, TJS_W("Object")))
-		{
-			return TJS_S_TRUE;
-		}
+		static ttstr Object_name(TJSMapGlobalStringMap(TJS_W("Object")));
+		if(Object_name == classname) return TJS_S_TRUE;
 
 		// look for the class instance information
 		for(tjs_uint i=0; i<ClassNames.size(); i++)
 		{
-			if(!TJS_strcmp(ClassNames[i].c_str(), classname))
-			{
-				return TJS_S_TRUE;
-			}
+			if(ClassNames[i] == classname) return TJS_S_TRUE;
 		}
 
 		return TJS_S_FALSE;

--- a/tjs2/tjsObjectExtendable.cpp
+++ b/tjs2/tjsObjectExtendable.cpp
@@ -24,7 +24,7 @@ void tTJSExtendableObject::SetSuper( iTJSDispatch2* dsp ) {
 }
 void tTJSExtendableObject::ExtendsClass( iTJSDispatch2* global, const ttstr& classname ) {
 	tTJSVariant val;
-	tjs_error er = global->PropGet( TJS_MEMBERMUSTEXIST, classname.c_str(), NULL, &val, global );
+	tjs_error er = global->PropGet( TJS_MEMBERMUSTEXIST, classname.c_str(), classname.GetHint(), &val, global );
 	if( TJS_FAILED(er) ) TJSThrowFrom_tjs_error( er, classname.c_str() );
 
 	SetSuper( val.AsObjectNoAddRef() );

--- a/tjs2/tjsRandomGenerator.cpp
+++ b/tjs2/tjsRandomGenerator.cpp
@@ -16,6 +16,7 @@
 #include "tjsRandomGenerator.h"
 #include "tjsDictionary.h"
 #include "tjsLex.h"
+#include "tjsGlobalStringMap.h"
 
 
 namespace TJS
@@ -89,8 +90,9 @@ void tTJSNI_RandomGenerator::Randomize(tTJSVariant ** param, tjs_int numparams)
 				data = new tTJSMersenneTwisterData;
 
 				// get state array
-				TJS_THROW_IF_ERROR(clo.PropGet(TJS_MEMBERMUSTEXIST, TJS_W("state"),
-					NULL, &val, NULL));
+				static ttstr state_name(TJSMapGlobalStringMap(TJS_W("state")));
+				TJS_THROW_IF_ERROR(clo.PropGet(TJS_MEMBERMUSTEXIST, state_name.c_str(),
+					state_name.GetHint(), &val, NULL));
 
 				state = val;
 				if(state.GetLen() != TJS_MT_N * 8)
@@ -117,11 +119,13 @@ void tTJSNI_RandomGenerator::Randomize(tTJSVariant ** param, tjs_int numparams)
 				}
 
 				// get other members
-				TJS_THROW_IF_ERROR(clo.PropGet(TJS_MEMBERMUSTEXIST, TJS_W("left"), NULL,
+				static ttstr left_name(TJSMapGlobalStringMap(TJS_W("left")));
+				TJS_THROW_IF_ERROR(clo.PropGet(TJS_MEMBERMUSTEXIST, left_name.c_str(), left_name.GetHint(),
 					&val, NULL));
 				data->left = (tjs_int)val;
 
-				TJS_THROW_IF_ERROR(clo.PropGet(TJS_MEMBERMUSTEXIST, TJS_W("next"), NULL,
+				static ttstr next_name(TJSMapGlobalStringMap(TJS_W("next")));
+				TJS_THROW_IF_ERROR(clo.PropGet(TJS_MEMBERMUSTEXIST, next_name.c_str(), next_name.GetHint(),
 					&val, NULL));
 				data->next = (tjs_int)val + data->state;
 
@@ -185,13 +189,16 @@ iTJSDispatch2 * tTJSNI_RandomGenerator::Serialize()
 		dic = TJSCreateDictionaryObject();
 
 		val = state;
-		dic->PropSet(TJS_MEMBERENSURE, TJS_W("state"), NULL, &val, dic);
+		static ttstr state_name(TJSMapGlobalStringMap(TJS_W("state")));
+		dic->PropSet(TJS_MEMBERENSURE, state_name.c_str(), state_name.GetHint(), &val, dic);
 
 		val = (tjs_int)data.left;
-		dic->PropSet(TJS_MEMBERENSURE, TJS_W("left"), NULL, &val, dic);
+		static ttstr left_name(TJSMapGlobalStringMap(TJS_W("left")));
+		dic->PropSet(TJS_MEMBERENSURE, left_name.c_str(), left_name.GetHint(), &val, dic);
 
 		val = (tjs_int)(data.next - data.state);
-		dic->PropSet(TJS_MEMBERENSURE, TJS_W("next"), NULL, &val, dic);
+		static ttstr next_name(TJSMapGlobalStringMap(TJS_W("next")));
+		dic->PropSet(TJS_MEMBERENSURE, next_name.c_str(), next_name.GetHint(), &val, dic);
 	}
 	catch(...)
 	{

--- a/utils/TimerIntf.cpp
+++ b/utils/TimerIntf.cpp
@@ -13,6 +13,7 @@
 #include "TimerIntf.h"
 #include "EventIntf.h"
 #include "SysInitIntf.h"
+#include "tjsGlobalStringMap.h"
 
 
 #define TVP_DEFAULT_TIMER_CAPACITY 6
@@ -78,7 +79,7 @@ void TJS_INTF_METHOD tTJSNI_Timer::Invalidate()
 void tTJSNI_Timer::Fire(tjs_uint n)
 {
 	if(!Owner) return;
-	static ttstr eventname(TJS_W("onTimer"));
+	static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTimer")));
 
 	tjs_int count = TVPCountEventsInQueue(Owner, Owner, eventname, 0);
 
@@ -116,7 +117,7 @@ void tTJSNI_Timer::CancelEvents()
 	// cancel all events
 	if(Owner)
 	{
-		static ttstr eventname(TJS_W("onTimer"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTimer")));
 		TVPCancelEvents(Owner, Owner, eventname, 0);
 	}
 }
@@ -127,7 +128,7 @@ bool tTJSNI_Timer::AreEventsInQueue()
 
 	if(Owner)
 	{
-		static ttstr eventname(TJS_W("onTimer"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTimer")));
 		return TVPAreEventsInQueue(Owner, Owner, eventname, 0);
 	}
 	return 0;

--- a/visual/BitmapLayerTreeOwner.cpp
+++ b/visual/BitmapLayerTreeOwner.cpp
@@ -13,6 +13,7 @@
 #include "ComplexRect.h"
 #include "BitmapIntf.h"
 #include "LayerIntf.h"
+#include "tjsGlobalStringMap.h"
 
 #include "BitmapLayerTreeOwner.h"
 #include "MsgIntf.h"
@@ -159,7 +160,7 @@ void TJS_INTF_METHOD tTJSNI_BitmapLayerTreeOwner::EndBitmapCompletion(iTVPLayerM
 void tTJSNI_BitmapLayerTreeOwner::OnSetMouseCursor( tjs_int cursor ) {
 	if( Owner ) {
 		tTJSVariant arg[1] = { cursor };
-		static ttstr eventname(TJS_W("onSetMouseCursor"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onSetMouseCursor")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 1, arg);
 	}
 }
@@ -168,7 +169,7 @@ void tTJSNI_BitmapLayerTreeOwner::OnGetCursorPos(tjs_int &x, tjs_int &y) {
 	if( Owner ) {
 		tjs_int vx = x, vy = y;
 		tTJSVariant arg[2] = { vx, vy };
-		static ttstr eventname(TJS_W("onGetCursorPos"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onGetCursorPos")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, arg);
 		x = arg[0];
 		y = arg[1];
@@ -178,14 +179,14 @@ void tTJSNI_BitmapLayerTreeOwner::OnGetCursorPos(tjs_int &x, tjs_int &y) {
 void tTJSNI_BitmapLayerTreeOwner::OnSetCursorPos(tjs_int x, tjs_int y) {
 	if( Owner ) {
 		tTJSVariant arg[2] = { x, y };
-		static ttstr eventname(TJS_W("onSetCursorPos"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onSetCursorPos")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, arg);
 	}
 }
 //----------------------------------------------------------------------
 void tTJSNI_BitmapLayerTreeOwner::OnReleaseMouseCapture() {
 	if( Owner ) {
-		static ttstr eventname(TJS_W("onReleaseMouseCapture"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onReleaseMouseCapture")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -194,7 +195,7 @@ void tTJSNI_BitmapLayerTreeOwner::OnSetHintText(iTJSDispatch2* sender, const tts
 	if( Owner ) {
 		tTJSVariant clo(sender, sender);
 		tTJSVariant arg[2] = { clo, hint };
-		static ttstr eventname(TJS_W("onSetHintText"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onSetHintText")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, arg);
 	}
 }
@@ -205,14 +206,14 @@ void tTJSNI_BitmapLayerTreeOwner::OnResizeLayer( tjs_int w, tjs_int h ) {
 	}
 	if( Owner ) {
 		tTJSVariant arg[2] = { w, h };
-		static ttstr eventname(TJS_W("onResizeLayer"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onResizeLayer")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, arg);
 	}
 }
 //----------------------------------------------------------------------
 void tTJSNI_BitmapLayerTreeOwner::OnChangeLayerImage() {
 	if( Owner ) {
-		static ttstr eventname(TJS_W("onChangeLayerImage"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onChangeLayerImage")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -222,14 +223,14 @@ void tTJSNI_BitmapLayerTreeOwner::OnSetAttentionPoint(tTJSNI_BaseLayer *layer, t
 		iTJSDispatch2* owner = GetOwnerNoAddRef();
 		tTJSVariant clo(owner, owner);
 		tTJSVariant arg[3] = { clo, x, y };
-		static ttstr eventname(TJS_W("onSetAttentionPoint"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onSetAttentionPoint")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 3, arg);
 	}
 }
 //----------------------------------------------------------------------
 void tTJSNI_BitmapLayerTreeOwner::OnDisableAttentionPoint() {
 	if( Owner ) {
-		static ttstr eventname(TJS_W("onDisableAttentionPoint"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onDisableAttentionPoint")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -237,14 +238,14 @@ void tTJSNI_BitmapLayerTreeOwner::OnDisableAttentionPoint() {
 void tTJSNI_BitmapLayerTreeOwner::OnSetImeMode(tjs_int mode) {
 	if( Owner ) {
 		tTJSVariant arg[1] = { mode };
-		static ttstr eventname(TJS_W("onSetImeMode"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onSetImeMode")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 1, arg);
 	}
 }
 //----------------------------------------------------------------------
 void tTJSNI_BitmapLayerTreeOwner::OnResetImeMode() {
 	if( Owner ) {
-		static ttstr eventname(TJS_W("onResetImeMode"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onResetImeMode")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }

--- a/visual/GraphicsLoadThread.cpp
+++ b/visual/GraphicsLoadThread.cpp
@@ -13,6 +13,7 @@
 #include "UtilStreams.h"
 #include "BitmapBitsAlloc.h"
 #include "LayerIntf.h"
+#include "tjsGlobalStringMap.h"
 
 tTVPTmpBitmapImage::tTVPTmpBitmapImage()
 	: w(0), h(0), pitch(0), buf(NULL), MetaInfo(NULL)
@@ -135,7 +136,7 @@ void tTVPAsyncImageLoader::HandleLoadedImage() {
 				param[1] = 1; // true async
 				param[2] = 1; // true error
 				param[3] = cmd->result_; // error_mes
-				static ttstr eventname(TJS_W("onLoaded"));
+				static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onLoaded")));
 				if( cmd->owner_->IsValid(0,NULL,NULL,cmd->owner_) == TJS_S_TRUE ) {
 					TVPPostEvent(cmd->owner_, cmd->owner_, eventname, 0, TVP_EPT_IMMEDIATE, 4, param);
 				}
@@ -164,7 +165,7 @@ void tTVPAsyncImageLoader::HandleLoadedImage() {
 				param[1] = 1; // true async
 				param[2] = 0; // false error
 				param[3] = TJS_W(""); // error_mes
-				static ttstr eventname(TJS_W("onLoaded"));
+				static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onLoaded")));
 				if( cmd->owner_->IsValid(0,NULL,NULL,cmd->owner_) == TJS_S_TRUE ) {
 					TVPPostEvent(cmd->owner_, cmd->owner_, eventname, 0, TVP_EPT_IMMEDIATE, 4, param);
 				}
@@ -193,7 +194,7 @@ void tTVPAsyncImageLoader::LoadRequest( iTJSDispatch2 *owner, tTJSNI_Bitmap* bmp
 		param[1] = 0; // false
 		param[2] = 0; // false
 		param[3] = TJS_W(""); // error_mes
-		static ttstr eventname(TJS_W("onLoaded"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onLoaded")));
 		TVPPostEvent(owner, owner, eventname, 0, TVP_EPT_IMMEDIATE, 4, param);
 		return;
 	}

--- a/visual/GraphicsLoaderIntf.cpp
+++ b/visual/GraphicsLoaderIntf.cpp
@@ -30,6 +30,7 @@
 #include <cstdlib>
 #include <cmath>
 #include "StorageImpl.h"
+#include "tjsGlobalStringMap.h"
 
 //---------------------------------------------------------------------------
 
@@ -768,7 +769,8 @@ void TVPSaveAsBMP( void* formatdata, tTJSBinaryStream* dst, const tTVPBaseBitmap
 	if( meta )
 	{
 		tTJSVariant val;
-		tjs_error er = meta->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("bpp"), NULL, &val, meta);
+		static ttstr bpp_name(TJSMapGlobalStringMap(TJS_W("bpp")));
+		tjs_error er = meta->PropGet(TJS_MEMBERMUSTEXIST, bpp_name.c_str(), bpp_name.GetHint(), &val, meta);
 		if(TJS_SUCCEEDED(er))
 		{
 			tjs_int index = (tjs_int)val.AsInteger();
@@ -925,13 +927,17 @@ void TVPLoadHeaderBMP( void* formatdata, tTJSBinaryStream *src, iTJSDispatch2** 
 
 	*dic = TJSCreateDictionaryObject();
 	tTJSVariant val(bi.biWidth);
-	(*dic)->PropSet(TJS_MEMBERENSURE, TJS_W("width"), 0, &val, (*dic) );
+	static ttstr width_name(TJSMapGlobalStringMap(TJS_W("width")));
+	(*dic)->PropSet(TJS_MEMBERENSURE, width_name.c_str(), width_name.GetHint(), &val, (*dic) );
 	val = tTJSVariant(bi.biHeight);
-	(*dic)->PropSet(TJS_MEMBERENSURE, TJS_W("height"), 0, &val, (*dic) );
+	static ttstr height_name(TJSMapGlobalStringMap(TJS_W("height")));
+	(*dic)->PropSet(TJS_MEMBERENSURE, height_name.c_str(), height_name.GetHint(), &val, (*dic) );
 	val = tTJSVariant(bi.biBitCount);
-	(*dic)->PropSet(TJS_MEMBERENSURE, TJS_W("bpp"), 0, &val, (*dic) );
+	static ttstr bpp_name(TJSMapGlobalStringMap(TJS_W("bpp")));
+	(*dic)->PropSet(TJS_MEMBERENSURE, bpp_name.c_str(), bpp_name.GetHint(), &val, (*dic) );
 	val = tTJSVariant(palsize);
-	(*dic)->PropSet(TJS_MEMBERENSURE, TJS_W("palette"), 0, &val, (*dic) );
+	static ttstr palette_name(TJSMapGlobalStringMap(TJS_W("palette")));
+	(*dic)->PropSet(TJS_MEMBERENSURE, palette_name.c_str(), palette_name.GetHint(), &val, (*dic) );
 }
 
 //---------------------------------------------------------------------------

--- a/visual/LayerBitmapImpl.cpp
+++ b/visual/LayerBitmapImpl.cpp
@@ -29,6 +29,7 @@
 #include "WindowFormUnit.h"
 #endif
 #include "UtilStreams.h"
+#include "tjsGlobalStringMap.h"
 
 //#include "FontSelectFormUnit.h"
 
@@ -1117,7 +1118,8 @@ void tTVPNativeBaseBitmap::DrawGlyph(iTJSDispatch2* glyph, const tTVPRect &destr
 
 	tjs_int itemcount;
 	tTJSVariant tmp;
-	if(TJS_SUCCEEDED(glyph->PropGet(TJS_MEMBERMUSTEXIST, TJS_W("count"), 0, &tmp, glyph)))
+	static ttstr count_name(TJSMapGlobalStringMap(TJS_W("count")));
+	if(TJS_SUCCEEDED(glyph->PropGet(TJS_MEMBERMUSTEXIST, count_name.c_str(), count_name.GetHint(), &tmp, glyph)))
 		itemcount = tmp;
 	else
 		itemcount = 0;

--- a/visual/LayerIntf.cpp
+++ b/visual/LayerIntf.cpp
@@ -29,6 +29,7 @@
 #include "DebugIntf.h"
 #include "LayerManager.h"
 #include "BitmapIntf.h"
+#include "tjsGlobalStringMap.h"
 
 #include "TVPColor.h"
 #ifdef _WIN32
@@ -440,7 +441,8 @@ tTJSNI_BaseLayer::Construct(tjs_int numparams, tTJSVariant **param,
 
 	class iTVPLayerTreeOwner* lto = NULL;
 	tTJSVariant iface_v;
-	if(TJS_FAILED(clo.PropGet(0, TJS_W("layerTreeOwnerInterface"), NULL, &iface_v, NULL)))
+	static ttstr layerTreeOwnerInterface_name(TJSMapGlobalStringMap(TJS_W("layerTreeOwnerInterface")));
+	if(TJS_FAILED(clo.PropGet(0, layerTreeOwnerInterface_name.c_str(), layerTreeOwnerInterface_name.GetHint(), &iface_v, NULL)))
 		TVPThrowExceptionMessage( TJS_W("Cannot Retrive Layer Tree Owner Interface.") );
 	lto = reinterpret_cast<iTVPLayerTreeOwner *>((tjs_intptr_t)(tjs_int64)iface_v);
 
@@ -645,7 +647,8 @@ iTJSDispatch2 * tTJSNI_BaseLayer::GetChildrenArrayObjectNoAddRef()
 		{
 			tTJSVariant val;
 			tjs_error er;
-			er = classobj->PropGet(0, TJS_W("clear"), NULL, &val, classobj);
+			static ttstr clear_name(TJSMapGlobalStringMap(TJS_W("clear")));
+			er = classobj->PropGet(0, clear_name.c_str(), clear_name.GetHint(), &val, classobj);
 				// retrieve clear method
 			if(TJS_FAILED(er)) TVPThrowInternalError;
 			ArrayClearMethod = val.AsObject();
@@ -2476,19 +2479,23 @@ void tTJSNI_BaseLayer::SaveLayerImage(const ttstr &name, const ttstr &type)
 		case ltPsExclusion:			val = tTJSVariant(TJS_W("psexcl"));		break;
 		default:					val = tTJSVariant(TJS_W("opaque"));		break;
 		}
-		dic->PropSet(TJS_MEMBERENSURE, TJS_W("mode"), 0, &val, dic );
+		static ttstr mode_name(TJSMapGlobalStringMap(TJS_W("mode")));
+		dic->PropSet(TJS_MEMBERENSURE, mode_name.c_str(), mode_name.GetHint(), &val, dic );
 
 		if( ImageLeft > 0 ) {
 			val = tTJSVariant(ImageLeft);
-			dic->PropSet(TJS_MEMBERENSURE, TJS_W("offs_x"), 0, &val, dic );
+			static ttstr offs_x_name(TJSMapGlobalStringMap(TJS_W("offs_x")));
+			dic->PropSet(TJS_MEMBERENSURE, offs_x_name.c_str(), offs_x_name.GetHint(), &val, dic );
 		}
 		if( ImageTop > 0 ) {
 			val = tTJSVariant(ImageTop);
-			dic->PropSet(TJS_MEMBERENSURE, TJS_W("offs_y"), 0, &val, dic );
+			static ttstr offs_y_name(TJSMapGlobalStringMap(TJS_W("offs_y")));
+			dic->PropSet(TJS_MEMBERENSURE, offs_y_name.c_str(), offs_y_name.GetHint(), &val, dic );
 		}
 		if( ImageLeft > 0 || ImageTop > 0 ) {
 			val = tTJSVariant(TJS_W("pixel"));
-			dic->PropSet(TJS_MEMBERENSURE, TJS_W("offs_unit"), 0, &val, dic );
+			static ttstr offs_unit_name(TJSMapGlobalStringMap(TJS_W("offs_unit")));
+			dic->PropSet(TJS_MEMBERENSURE, offs_unit_name.c_str(), offs_unit_name.GetHint(), &val, dic );
 		}
 		TVPSaveImage( name, type, MainImage, dic );
 	} catch(...) {

--- a/visual/LayerIntf.cpp
+++ b/visual/LayerIntf.cpp
@@ -38,6 +38,7 @@
 #include "RectItf.h"
 #include "FontSystem.h"
 #include "tjsDictionary.h"
+#include "tjsGlobalStringMap.h"
 
 #ifdef __ANDROID__
 #include "VirtualKey.h"
@@ -2956,7 +2957,7 @@ bool tTJSNI_BaseLayer::HitTestNoVisibleCheck(tjs_int x, tjs_int y)
 			param[0] = x;
 			param[1] = y;
 			param[2] = true;
-			static ttstr eventname(TJS_W("onHitTest"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onHitTest")));
 			TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 3, param);
 
 			res = OnHitTest_Work;
@@ -3044,7 +3045,7 @@ void tTJSNI_BaseLayer::FireClick(tjs_int x, tjs_int y)
 		tTJSVariant param[2];
 		param[0] = x;
 		param[1] = y;
-		static ttstr eventname(TJS_W("onClick"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onClick")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, param);
 	}
 }
@@ -3056,7 +3057,7 @@ void tTJSNI_BaseLayer::FireDoubleClick(tjs_int x, tjs_int y)
 		tTJSVariant param[2];
 		param[0] = x;
 		param[1] = y;
-		static ttstr eventname(TJS_W("onDoubleClick"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onDoubleClick")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, param);
 	}
 }
@@ -3071,7 +3072,7 @@ void tTJSNI_BaseLayer::FireMouseDown(tjs_int x, tjs_int y, tTVPMouseButton mb,
 		param[1] = y;
 		param[2] = (tjs_int) mb;
 		param[3] = (tjs_int64)flags;
-		static ttstr eventname(TJS_W("onMouseDown"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseDown")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 4, param);
 	}
 }
@@ -3086,7 +3087,7 @@ void tTJSNI_BaseLayer::FireMouseUp(tjs_int x, tjs_int y, tTVPMouseButton mb,
 		param[1] = y;
 		param[2] = (tjs_int) mb;
 		param[3] = (tjs_int64)flags;
-		static ttstr eventname(TJS_W("onMouseUp"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseUp")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 4, param);
 	}
 }
@@ -3099,7 +3100,7 @@ void tTJSNI_BaseLayer::FireMouseMove(tjs_int x, tjs_int y, tjs_uint32 flags)
 		param[0] = x;
 		param[1] = y;
 		param[2] = (tjs_int64)flags;
-		static ttstr eventname(TJS_W("onMouseMove"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseMove")));
 		TVPPostEvent(Owner, Owner, eventname, 0,
 			TVP_EPT_IMMEDIATE|TVP_EPT_DISCARDABLE, 3, param);
 	}
@@ -3109,7 +3110,7 @@ void tTJSNI_BaseLayer::FireMouseEnter()
 {
 	if(Owner && !Shutdown)
 	{
-		static ttstr eventname(TJS_W("onMouseEnter"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseEnter")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -3118,7 +3119,7 @@ void tTJSNI_BaseLayer::FireMouseLeave()
 {
 	if(Owner && !Shutdown)
 	{
-		static ttstr eventname(TJS_W("onMouseLeave"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseLeave")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -3148,7 +3149,7 @@ void tTJSNI_BaseLayer::FireTouchDown( tjs_real x, tjs_real y, tjs_real cx, tjs_r
 	if(Owner && !Shutdown)
 	{
 		tTJSVariant arg[5] = { x, y, cx, cy, (tjs_int64)id };
-		static ttstr eventname(TJS_W("onTouchDown"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchDown")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 5, arg);
 	}
 }
@@ -3158,7 +3159,7 @@ void tTJSNI_BaseLayer::FireTouchUp( tjs_real x, tjs_real y, tjs_real cx, tjs_rea
 	if(Owner && !Shutdown)
 	{
 		tTJSVariant arg[5] = { x, y, cx, cy, (tjs_int64)id };
-		static ttstr eventname(TJS_W("onTouchUp"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchUp")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 5, arg);
 	}
 }
@@ -3168,7 +3169,7 @@ void tTJSNI_BaseLayer::FireTouchMove( tjs_real x, tjs_real y, tjs_real cx, tjs_r
 	if(Owner && !Shutdown)
 	{
 		tTJSVariant arg[5] = { x, y, cx, cy, (tjs_int64)id };
-		static ttstr eventname(TJS_W("onTouchMove"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchMove")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE|TVP_EPT_DISCARDABLE, 5, arg);
 	}
 }
@@ -3178,7 +3179,7 @@ void tTJSNI_BaseLayer::FireTouchScaling( tjs_real startdist, tjs_real curdist, t
 	if(Owner && !Shutdown)
 	{
 		tTJSVariant arg[5] = { startdist, curdist, cx, cy, flag };
-		static ttstr eventname(TJS_W("onTouchScaling"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchScaling")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 5, arg);
 	}
 }
@@ -3188,7 +3189,7 @@ void tTJSNI_BaseLayer::FireTouchRotate( tjs_real startangle, tjs_real curangle, 
 	if(Owner && !Shutdown)
 	{
 		tTJSVariant arg[6] = { startangle, curangle, dist, cx, cy, flag };
-		static ttstr eventname(TJS_W("onTouchRotate"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchRotate")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 6, arg);
 	}
 }
@@ -3197,7 +3198,7 @@ void tTJSNI_BaseLayer::FireMultiTouch()
 {
 	if(Owner && !Shutdown)
 	{
-		static ttstr eventname(TJS_W("onMultiTouch"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMultiTouch")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -3271,7 +3272,7 @@ tTJSNI_BaseLayer *tTJSNI_BaseLayer::GetPrevFocusable()
 	if(Owner && !Shutdown &&
 		(!FocusWork || FocusWork->Owner))
 	{
-		static ttstr eventname(TJS_W("onSearchPrevFocusable"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onSearchPrevFocusable")));
 		tTJSVariant param[1];
 		if(FocusWork)
 			param[0] = tTJSVariant(FocusWork->Owner,
@@ -3310,7 +3311,7 @@ tTJSNI_BaseLayer *tTJSNI_BaseLayer::GetNextFocusable()
 	if(Owner && !Shutdown &&
 		(!FocusWork || FocusWork->Owner))
 	{
-		static ttstr eventname(TJS_W("onSearchNextFocusable"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onSearchNextFocusable")));
 		tTJSVariant param[1];
 		if(FocusWork)
 			param[0] = tTJSVariant(FocusWork->Owner,
@@ -3360,7 +3361,7 @@ void tTJSNI_BaseLayer::FireBlur(tTJSNI_BaseLayer *prevfocused)
 {
 	if(Owner && !Shutdown)
 	{
-		static ttstr eventname(TJS_W("onBlur"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onBlur")));
 		tTJSVariant param[1];
 		if(prevfocused)
 			param[0] = tTJSVariant(prevfocused->Owner, prevfocused->Owner);
@@ -3376,7 +3377,7 @@ void tTJSNI_BaseLayer::FireFocus(tTJSNI_BaseLayer *prevfocused, bool direction)
 {
 	if(Owner && !Shutdown)
 	{
-		static ttstr eventname(TJS_W("onFocus"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onFocus")));
 		tTJSVariant param[2];
 		if(prevfocused)
 			param[0] = tTJSVariant(prevfocused->Owner, prevfocused->Owner);
@@ -3394,7 +3395,7 @@ tTJSNI_BaseLayer * tTJSNI_BaseLayer::FireBeforeFocus(
 	FocusWork = this;
 	if(Owner && !Shutdown)
 	{
-		static ttstr eventname(TJS_W("onBeforeFocus"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onBeforeFocus")));
 		tTJSVariant param[3];
 		param[0] = tTJSVariant(Owner, Owner);
 		if(prevfocused)
@@ -3435,12 +3436,12 @@ void tTJSNI_BaseLayer::NotifyNodeEnabledState()
 	{
 		if(en)
 		{
-			static ttstr eventname(TJS_W("onNodeEnabled"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onNodeEnabled")));
 			TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 		}
 		else
 		{
-			static ttstr eventname(TJS_W("onNodeDisabled"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onNodeDisabled")));
 			TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 		}
 	}
@@ -3512,7 +3513,7 @@ void tTJSNI_BaseLayer::FireKeyDown(tjs_uint key, tjs_uint32 shift)
 		param[0] = (tjs_int)key;
 		param[1] = (tjs_int)shift;
 		param[2] = true;
-		static ttstr eventname(TJS_W("onKeyDown"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onKeyDown")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 3, param);
 	}
 }
@@ -3525,7 +3526,7 @@ void tTJSNI_BaseLayer::FireKeyUp(tjs_uint key, tjs_uint32 shift)
 		param[0] = (tjs_int)key;
 		param[1] = (tjs_int)shift;
 		param[2] = true;
-		static ttstr eventname(TJS_W("onKeyUp"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onKeyUp")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 3, param);
 	}
 }
@@ -3540,7 +3541,7 @@ void tTJSNI_BaseLayer::FireKeyPress(tjs_char key)
 		tTJSVariant param[2];
 		param[0] = buf;
 		param[1] = true;
-		static ttstr eventname(TJS_W("onKeyPress"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onKeyPress")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, param);
 	}
 }
@@ -3551,7 +3552,7 @@ void tTJSNI_BaseLayer::FireMouseWheel(tjs_uint32 shift, tjs_int delta, tjs_int x
 	if(Owner && !Shutdown)
 	{
 		tTJSVariant val[4] = { (tjs_int)shift, delta, x, y };
-		static ttstr eventname(TJS_W("onMouseWheel"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseWheel")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 4, val);
 	}
 }
@@ -5045,7 +5046,7 @@ void tTJSNI_BaseLayer::BeforeCompletion()
 	if(CallOnPaint)
 	{
 		CallOnPaint = false;
-		static ttstr eventname(TJS_W("onPaint"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onPaint")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 
@@ -6215,7 +6216,7 @@ void tTJSNI_BaseLayer::StartTransition(const ttstr &name, bool withchildren,
 		// check selfupdate member of 'options'
 		tTJSVariant var;
 		TransSelfUpdate = false;
-		static ttstr selfupdate_name(TJS_W("selfupdate"));
+		static ttstr selfupdate_name(TJSMapGlobalStringMap(TJS_W("selfupdate")));
 		if(TJS_SUCCEEDED(options.PropGet(0, selfupdate_name.c_str(),
 			selfupdate_name.GetHint(), &var, NULL)))
 		{
@@ -6226,7 +6227,7 @@ void tTJSNI_BaseLayer::StartTransition(const ttstr &name, bool withchildren,
 
 		// check callback member of 'options'
 		TransTickCallback = tTJSVariantClosure(NULL, NULL);
-		static ttstr callback_name(TJS_W("callback"));
+		static ttstr callback_name(TJSMapGlobalStringMap(TJS_W("callback")));
 		UseTransTickCallback = false;
 		if(TJS_SUCCEEDED(options.PropGet(0, callback_name.c_str(),
 			callback_name.GetHint(), &var, NULL)))
@@ -6414,7 +6415,7 @@ void tTJSNI_BaseLayer::InternalStopTransition()
 		// fire event
 		if(Owner && !Shutdown && transsrcalive)
 		{
-			static ttstr eventname(TJS_W("onTransitionCompleted"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTransitionCompleted")));
 
 			// fire SYNCHRONOUS event of "onTransitionCompleted"
 			tTJSVariant param[2];

--- a/visual/VideoOvlIntf.cpp
+++ b/visual/VideoOvlIntf.cpp
@@ -14,6 +14,7 @@
 #include "WindowIntf.h"
 #include "VideoOvlIntf.h"
 #include "LayerIntf.h"
+#include "tjsGlobalStringMap.h"
 
 //---------------------------------------------------------------------------
 // tTJSNI_BaseVideoOverlay
@@ -63,16 +64,16 @@ void TJS_INTF_METHOD tTJSNI_BaseVideoOverlay::Invalidate()
 //---------------------------------------------------------------------------
 ttstr tTJSNI_BaseVideoOverlay::GetStatusString() const
 {
-	static ttstr unload(TJS_W("unload"));
-	static ttstr play(TJS_W("play"));
-	static ttstr stop(TJS_W("stop"));
-	static ttstr unknown(TJS_W("unknown"));
-	static ttstr pause(TJS_W("pause"));
-	static ttstr ready(TJS_W("ready"));
-	static ttstr idle(TJS_W("idle"));
-	static ttstr buffering(TJS_W("buffering"));
-	static ttstr loadError(TJS_W("load error"));
-	static ttstr playerError(TJS_W("player error"));
+	static ttstr unload(TJSMapGlobalStringMap(TJS_W("unload")));
+	static ttstr play(TJSMapGlobalStringMap(TJS_W("play")));
+	static ttstr stop(TJSMapGlobalStringMap(TJS_W("stop")));
+	static ttstr unknown(TJSMapGlobalStringMap(TJS_W("unknown")));
+	static ttstr pause(TJSMapGlobalStringMap(TJS_W("pause")));
+	static ttstr ready(TJSMapGlobalStringMap(TJS_W("ready")));
+	static ttstr idle(TJSMapGlobalStringMap(TJS_W("idle")));
+	static ttstr buffering(TJSMapGlobalStringMap(TJS_W("buffering")));
+	static ttstr loadError(TJSMapGlobalStringMap(TJS_W("load error")));
+	static ttstr playerError(TJSMapGlobalStringMap(TJS_W("player error")));
 
 	switch(Status)
 	{
@@ -107,7 +108,7 @@ void tTJSNI_BaseVideoOverlay::SetStatus(tTVPVideoOverlayStatus s)
 			{
 				// fire onStatusChanged event
 				tTJSVariant param(GetStatusString());
-				static ttstr eventname(TJS_W("onStatusChanged"));
+				static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onStatusChanged")));
 				TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE,
 					1, &param);
 			}
@@ -133,7 +134,7 @@ void tTJSNI_BaseVideoOverlay::SetStatusAsync(tTVPVideoOverlayStatus s)
 			{
 				// fire onStatusChanged event
 				tTJSVariant param(GetStatusString());
-				static ttstr eventname(TJS_W("onStatusChanged"));
+				static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onStatusChanged")));
 				TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_POST,
 					1, &param);
 			}
@@ -153,7 +154,7 @@ void tTJSNI_BaseVideoOverlay::FireCallbackCommand(const ttstr & command,
 		{
 			// fire onStatusChanged event
 			tTJSVariant param[2] = {command, argument};
-			static ttstr eventname(TJS_W("onCallbackCommand"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onCallbackCommand")));
 			TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE,
 				2, param);
 		}
@@ -172,7 +173,7 @@ void tTJSNI_BaseVideoOverlay::FirePeriodEvent(tTVPPeriodEventReason reason)
 		{
 			// fire onPeriod event
 			tTJSVariant param[1] = {(tjs_int)reason};
-			static ttstr eventname(TJS_W("onPeriod"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onPeriod")));
 			TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE,
 				1, param);
 		}
@@ -191,7 +192,7 @@ void tTJSNI_BaseVideoOverlay::FireFrameUpdateEvent( tjs_int frame )
 		{
 			// fire onPeriod event
 			tTJSVariant param[1] = {frame};
-			static ttstr eventname(TJS_W("onFrameUpdate"));
+			static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onFrameUpdate")));
 			TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE,
 				1, param);
 		}

--- a/visual/WindowIntf.cpp
+++ b/visual/WindowIntf.cpp
@@ -346,7 +346,8 @@ void tTJSNI_BaseWindow::SetDrawDeviceObject(const tTJSVariant & val)
 	{
 		tTJSVariantClosure clo = DrawDeviceObject.AsObjectClosureNoAddRef();
 		tTJSVariant iface_v;
-		if(TJS_FAILED(clo.PropGet(0, TJS_W("interface"), NULL, &iface_v, NULL)))
+		static ttstr interface_name(TJSMapGlobalStringMap(TJS_W("interface")));
+		if(TJS_FAILED(clo.PropGet(0, interface_name.c_str(), interface_name.GetHint(), &iface_v, NULL)))
 			TVPThrowExceptionMessage( TVPCannotRetriveInterfaceFromDrawDevice );
 		DrawDevice =
 			reinterpret_cast<iTVPDrawDevice *>((tjs_intptr_t)(tjs_int64)iface_v);

--- a/visual/WindowIntf.cpp
+++ b/visual/WindowIntf.cpp
@@ -24,6 +24,7 @@
 #include "VideoOvlIntf.h"
 #include "DrawDevice.h"
 #include "CanvasIntf.h"
+#include "tjsGlobalStringMap.h"
 
 #include "Application.h"
 
@@ -382,7 +383,7 @@ void tTJSNI_BaseWindow::OnClose()
 	if(Owner)
 	{
 		tTJSVariant arg[1] = {true};
-		static ttstr eventname(TJS_W("onCloseQuery"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onCloseQuery")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 1, arg);
 	}
 }
@@ -392,7 +393,7 @@ void tTJSNI_BaseWindow::OnResize()
 	if(!CanDeliverEvents()) return;
 	if(Owner)
 	{
-		static ttstr eventname(TJS_W("onResize"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onResize")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -403,7 +404,7 @@ void tTJSNI_BaseWindow::OnClick(tjs_int x, tjs_int y)
 	if(Owner)
 	{
 		tTJSVariant arg[2] = { x, y };
-		static ttstr eventname(TJS_W("onClick"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onClick")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, arg);
 	}
 	if(DrawDevice) DrawDevice->OnClick(x, y);
@@ -415,7 +416,7 @@ void tTJSNI_BaseWindow::OnDoubleClick(tjs_int x, tjs_int y)
 	if(Owner)
 	{
 		tTJSVariant arg[2] = { x, y };
-		static ttstr eventname(TJS_W("onDoubleClick"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onDoubleClick")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, arg);
 	}
 	if(DrawDevice) DrawDevice->OnDoubleClick(x, y);
@@ -428,7 +429,7 @@ void tTJSNI_BaseWindow::OnMouseDown(tjs_int x, tjs_int y, tTVPMouseButton mb,
 	if(Owner)
 	{
 		tTJSVariant arg[4] = { x, y, (tjs_int64)mb, (tjs_int64)flags };
-		static ttstr eventname(TJS_W("onMouseDown"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseDown")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 4, arg);
 	}
 	if(DrawDevice) DrawDevice->OnMouseDown(x, y, mb, flags);
@@ -441,7 +442,7 @@ void tTJSNI_BaseWindow::OnMouseUp(tjs_int x, tjs_int y, tTVPMouseButton mb,
 	if(Owner)
 	{
 		tTJSVariant arg[4] = { x, y, (tjs_int)mb, (tjs_int)flags };
-		static ttstr eventname(TJS_W("onMouseUp"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseUp")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 4, arg);
 	}
 	if(DrawDevice) DrawDevice->OnMouseUp(x, y, mb, flags);
@@ -452,7 +453,7 @@ void tTJSNI_BaseWindow::OnMouseMove(tjs_int x, tjs_int y, tjs_uint32 flags)
 	if(!CanDeliverEvents()) return;
 	if(Owner)
 	{
-		static ttstr eventname(TJS_W("onMouseMove"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseMove")));
 			tTJSVariant arg[3] = { x, y, (tjs_int64)flags };
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_DISCARDABLE|TVP_EPT_IMMEDIATE
 			/*discardable!!*/,
@@ -466,7 +467,7 @@ void tTJSNI_BaseWindow::OnTouchDown( tjs_real x, tjs_real y, tjs_real cx, tjs_re
 	if(Owner)
 	{
 		tTJSVariant arg[5] = { x, y, cx, cy, (tjs_int64)id };
-		static ttstr eventname(TJS_W("onTouchDown"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchDown")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 5, arg);
 	}
 	if(DrawDevice) DrawDevice->OnTouchDown(x, y, cx, cy, id);
@@ -477,7 +478,7 @@ void tTJSNI_BaseWindow::OnTouchUp( tjs_real x, tjs_real y, tjs_real cx, tjs_real
 	if(Owner)
 	{
 		tTJSVariant arg[5] = { x, y, cx, cy, (tjs_int64)id };
-		static ttstr eventname(TJS_W("onTouchUp"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchUp")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 5, arg);
 	}
 	if(DrawDevice) DrawDevice->OnTouchUp(x, y, cx, cy, id);
@@ -488,7 +489,7 @@ void tTJSNI_BaseWindow::OnTouchMove( tjs_real x, tjs_real y, tjs_real cx, tjs_re
 	if(Owner)
 	{
 		tTJSVariant arg[5] = { x, y, cx, cy, (tjs_int64)id };
-		static ttstr eventname(TJS_W("onTouchMove"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchMove")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 5, arg);
 	}
 	if(DrawDevice) DrawDevice->OnTouchMove(x, y, cx, cy, id);
@@ -499,7 +500,7 @@ void tTJSNI_BaseWindow::OnPointerDown( tjs_int type, tjs_real x, tjs_real y, tjs
 	if( Owner )
 	{
 		tTJSVariant arg[7] = { type, x, y, cx, cy, (tjs_int64)flags, (tjs_int64)id };
-		static ttstr eventname( TJS_W( "onPointerDown" ) );
+		static ttstr eventname(TJSMapGlobalStringMap( TJS_W( "onPointerDown" ) ));
 		TVPPostEvent( Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 7, arg );
 	}
 }
@@ -509,7 +510,7 @@ void tTJSNI_BaseWindow::OnPointerMove( tjs_int type, tjs_real x, tjs_real y, tjs
 	if( Owner )
 	{
 		tTJSVariant arg[7] = { type, x, y, cx, cy, (tjs_int64)flags, (tjs_int64)id };
-		static ttstr eventname( TJS_W( "onPointerMove" ) );
+		static ttstr eventname(TJSMapGlobalStringMap( TJS_W( "onPointerMove" ) ));
 		TVPPostEvent( Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 7, arg );
 	}
 }
@@ -519,7 +520,7 @@ void tTJSNI_BaseWindow::OnPointerUp( tjs_int type, tjs_real x, tjs_real y, tjs_r
 	if( Owner )
 	{
 		tTJSVariant arg[7] = { type, x, y, cx, cy, (tjs_int64)flags, (tjs_int64)id };
-		static ttstr eventname( TJS_W( "onPointerUp" ) );
+		static ttstr eventname(TJSMapGlobalStringMap( TJS_W( "onPointerUp" ) ));
 		TVPPostEvent( Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 7, arg );
 	}
 }
@@ -529,7 +530,7 @@ void tTJSNI_BaseWindow::OnTouchScaling( tjs_real startdist, tjs_real curdist, tj
 	if(Owner)
 	{
 		tTJSVariant arg[5] = { startdist, curdist, cx, cy, flag };
-		static ttstr eventname(TJS_W("onTouchScaling"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchScaling")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 5, arg);
 	}
 	if(DrawDevice) DrawDevice->OnTouchScaling(startdist, curdist, cx, cy, flag);
@@ -540,7 +541,7 @@ void tTJSNI_BaseWindow::OnTouchRotate( tjs_real startangle, tjs_real curangle, t
 	if(Owner)
 	{
 		tTJSVariant arg[6] = { startangle, curangle, dist, cx, cy, flag };
-		static ttstr eventname(TJS_W("onTouchRotate"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onTouchRotate")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 6, arg);
 	}
 	if(DrawDevice) DrawDevice->OnTouchRotate(startangle, curangle, dist, cx, cy, flag);
@@ -550,7 +551,7 @@ void tTJSNI_BaseWindow::OnMultiTouch() {
 	if(!CanDeliverEvents()) return;
 	if(Owner)
 	{
-		static ttstr eventname(TJS_W("onMultiTouch"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMultiTouch")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 	if(DrawDevice) DrawDevice->OnMultiTouch();
@@ -573,7 +574,7 @@ void tTJSNI_BaseWindow::OnMouseEnter()
 	if(!CanDeliverEvents()) return;
 	if(Owner)
 	{
-		static ttstr eventname(TJS_W("onMouseEnter"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseEnter")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -583,7 +584,7 @@ void tTJSNI_BaseWindow::OnMouseLeave()
 	if(!CanDeliverEvents()) return;
 	if(Owner)
 	{
-		static ttstr eventname(TJS_W("onMouseLeave"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseLeave")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -594,7 +595,7 @@ void tTJSNI_BaseWindow::OnKeyDown(tjs_uint key, tjs_uint32 shift)
 	if(Owner)
 	{
 		tTJSVariant arg[2] = { (tjs_int)key, (tjs_int)shift };
-		static ttstr eventname(TJS_W("onKeyDown"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onKeyDown")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, arg);
 	}
 	if(DrawDevice) DrawDevice->OnKeyDown(key, shift);
@@ -606,7 +607,7 @@ void tTJSNI_BaseWindow::OnKeyUp(tjs_uint key, tjs_uint32 shift)
 	if(Owner)
 	{
 		tTJSVariant arg[2] = { (tjs_int)key, (tjs_int)shift };
-		static ttstr eventname(TJS_W("onKeyUp"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onKeyUp")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 2, arg);
 	}
 	if(DrawDevice) DrawDevice->OnKeyUp(key, shift);
@@ -621,7 +622,7 @@ void tTJSNI_BaseWindow::OnKeyPress(tjs_char key)
 		buf[0] = (tjs_char)key;
 		buf[1] = 0;
 		tTJSVariant arg[1] = { buf };
-		static ttstr eventname(TJS_W("onKeyPress"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onKeyPress")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 1, arg);
 	}
 	if(DrawDevice) DrawDevice->OnKeyPress(key);
@@ -633,7 +634,7 @@ void tTJSNI_BaseWindow::OnFileDrop(const tTJSVariant &array)
 	if(Owner)
 	{
 		tTJSVariant arg[1] = { array };
-		static ttstr eventname(TJS_W("onFileDrop"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onFileDrop")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 1, arg);
 	}
 }
@@ -645,7 +646,7 @@ void tTJSNI_BaseWindow::OnMouseWheel(tjs_uint32 shift, tjs_int delta,
 	if(Owner)
 	{
 		tTJSVariant arg[4] = { (tjs_int)shift, delta, x, y };
-		static ttstr eventname(TJS_W("onMouseWheel"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onMouseWheel")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 4, arg);
 	}
 	if(DrawDevice) DrawDevice->OnMouseWheel(shift, delta, x, y);
@@ -656,7 +657,7 @@ void tTJSNI_BaseWindow::OnPopupHide()
 	if(!CanDeliverEvents()) return;
 	if(Owner)
 	{
-		static ttstr eventname(TJS_W("onPopupHide"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onPopupHide")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, NULL);
 	}
 }
@@ -670,8 +671,8 @@ void tTJSNI_BaseWindow::OnActivate(bool activate_or_deactivate)
 	{
 		if(Owner)
 		{
-			static ttstr a_eventname(TJS_W("onActivate"));
-			static ttstr d_eventname(TJS_W("onDeactivate"));
+			static ttstr a_eventname(TJSMapGlobalStringMap(TJS_W("onActivate")));
+			static ttstr d_eventname(TJSMapGlobalStringMap(TJS_W("onDeactivate")));
 			TVPPostEvent(Owner, Owner, activate_or_deactivate?a_eventname:d_eventname,
 				0, TVP_EPT_IMMEDIATE, 0, NULL);
 		}
@@ -684,7 +685,7 @@ void tTJSNI_BaseWindow::OnHintChange( const ttstr& text, tjs_int x, tjs_int y, b
 	if(Owner)
 	{
 		tTJSVariant arg[6] = { text, x, y, isshow ? 1 : 0 };
-		static ttstr eventname(TJS_W("onHintChanged"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onHintChanged")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 4, arg);
 	}
 }
@@ -694,7 +695,7 @@ void tTJSNI_BaseWindow::OnDisplayRotate( tjs_int orientation, tjs_int rotate, tj
 	if(Owner)
 	{
 		tTJSVariant arg[5] = { orientation, rotate, bpp, hresolution, vresolution };
-		static ttstr eventname(TJS_W("onDisplayRotate"));
+		static ttstr eventname(TJSMapGlobalStringMap(TJS_W("onDisplayRotate")));
 		TVPPostEvent(Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 5, arg);
 	}
 	if(DrawDevice) DrawDevice->OnDisplayRotate(orientation, rotate, bpp, hresolution, vresolution);
@@ -716,7 +717,7 @@ void tTJSNI_BaseWindow::OnDraw() {
 	try {
 		if( Owner )
 		{
-			static ttstr eventname( TJS_W( "onDraw" ) );
+			static ttstr eventname(TJSMapGlobalStringMap( TJS_W( "onDraw" ) ));
 			TVPPostEvent( Owner, Owner, eventname, 0, TVP_EPT_IMMEDIATE, 0, nullptr );
 		}
 	} catch( ... ) {

--- a/visual/android/WindowImpl.cpp
+++ b/visual/android/WindowImpl.cpp
@@ -23,6 +23,7 @@
 #include "PluginImpl.h"
 #include "LayerManager.h"
 #include "EventIntf.h"
+#include "tjsGlobalStringMap.h"
 
 #include "Application.h"
 #include "tjsDictionary.h"
@@ -133,8 +134,8 @@ void tTJSNI_Window::PostInputEvent(const ttstr &name, iTJSDispatch2 * params)
 	// posts input event
 	if(!Form) return;
 
-	static ttstr key_name(TJS_W("key"));
-	static ttstr shift_name(TJS_W("shift"));
+	static ttstr key_name(TJSMapGlobalStringMap(TJS_W("key")));
+	static ttstr shift_name(TJSMapGlobalStringMap(TJS_W("shift")));
 
 	// check input event name
 	enum tEventType
@@ -1123,11 +1124,11 @@ TJS_BEGIN_NATIVE_METHOD_DECL(getTouchPoint)
 		if( result ) {
 			iTJSDispatch2 * object = TJSCreateDictionaryObject();
 
-			static ttstr startX_name(TJS_W("startX"));
-			static ttstr startY_name(TJS_W("startY"));
-			static ttstr X_name(TJS_W("x"));
-			static ttstr Y_name(TJS_W("y"));
-			static ttstr ID_name(TJS_W("ID"));
+			static ttstr startX_name(TJSMapGlobalStringMap(TJS_W("startX")));
+			static ttstr startY_name(TJSMapGlobalStringMap(TJS_W("startY")));
+			static ttstr X_name(TJSMapGlobalStringMap(TJS_W("x")));
+			static ttstr Y_name(TJSMapGlobalStringMap(TJS_W("y")));
+			static ttstr ID_name(TJSMapGlobalStringMap(TJS_W("ID")));
 			{
 				tTJSVariant val(_this->GetTouchPointStartX(index));
 				if(TJS_FAILED(object->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP, startX_name.c_str(), startX_name.GetHint(), &val, object)))

--- a/visual/win32/WindowImpl.cpp
+++ b/visual/win32/WindowImpl.cpp
@@ -34,6 +34,7 @@
 #include "VSyncTimingThread.h"
 #include "MouseCursor.h"
 #include "CanvasIntf.h"
+#include "tjsGlobalStringMap.h"
 
 //---------------------------------------------------------------------------
 // Mouse Cursor management
@@ -1159,8 +1160,8 @@ void tTJSNI_Window::PostInputEvent(const ttstr &name, iTJSDispatch2 * params)
 	// posts input event
 	if(!Form) return;
 
-	static ttstr key_name(TJS_W("key"));
-	static ttstr shift_name(TJS_W("shift"));
+	static ttstr key_name(TJSMapGlobalStringMap(TJS_W("key")));
+	static ttstr shift_name(TJSMapGlobalStringMap(TJS_W("shift")));
 
 	// check input event name
 	enum tEventType
@@ -2122,11 +2123,11 @@ TJS_BEGIN_NATIVE_METHOD_DECL(getTouchPoint)
 		if( result ) {
 			iTJSDispatch2 * object = TJSCreateDictionaryObject();
 
-			static ttstr startX_name(TJS_W("startX"));
-			static ttstr startY_name(TJS_W("startY"));
-			static ttstr X_name(TJS_W("x"));
-			static ttstr Y_name(TJS_W("y"));
-			static ttstr ID_name(TJS_W("ID"));
+			static ttstr startX_name(TJSMapGlobalStringMap(TJS_W("startX")));
+			static ttstr startY_name(TJSMapGlobalStringMap(TJS_W("startY")));
+			static ttstr X_name(TJSMapGlobalStringMap(TJS_W("x")));
+			static ttstr Y_name(TJSMapGlobalStringMap(TJS_W("y")));
+			static ttstr ID_name(TJSMapGlobalStringMap(TJS_W("ID")));
 			{
 				tTJSVariant val(_this->GetTouchPointStartX(index));
 				if(TJS_FAILED(object->PropSet(TJS_MEMBERENSURE|TJS_IGNOREPROP, startX_name.c_str(), startX_name.GetHint(), &val, object)))


### PR DESCRIPTION
As per the following article: https://nee.lv/2021/02/28/How-I-cut-GTA-Online-loading-times-by-70/

These changes will reduce the complexity of string comparisons, increasing performance in most cases:
* Using `TJSMapGlobalStringMap` where possible in order to use a single pointer for comparison instead of comparing a buffer
* Using `tTJSString::GetHint` where possible to reduce the time it takes to search the hash map
* Avoiding the use of `TJS_strcmp` which may introduce quadratic complexity
* Add direct pointer comparison of `const tjs_char *` to `TJS_strnicmp`, `TJS_stricmp`, `TJS_strcmp`, and `TJS_strncmp` (decreasing the string comparison complexity in most cases)