### PR TITLE
Add 144hz in options.contfreq field.

### DIFF
--- a/vcproj/option_desc_ja.json
+++ b/vcproj/option_desc_ja.json
@@ -34,7 +34,8 @@
 					{ "value":"93", "desc":"93Hz" },
 					{ "value":"100", "desc":"100Hz" },
 					{ "value":"107", "desc":"107Hz" },
-					{ "value":"120", "desc":"120Hz" }
+					{ "value":"120", "desc":"120Hz" },
+					{ "value":"144", "desc":"144hz" }
 				]
 			},
 			{


### PR DESCRIPTION
Display with 144Hz refresh rate, for example, `AOC 24G2W4`, is commonly seen in FPS players.