### PR TITLE
Fix for ignored right mouse button clicks

### DIFF
--- a/environ/win32/TVPWindow.cpp
+++ b/environ/win32/TVPWindow.cpp
@@ -113,7 +113,11 @@ LRESULT WINAPI tTVPWindow::Proc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
 		OnMouseUp( mbRight, GetShiftState(wParam), GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) );
 		return 0;
 	case WM_RBUTTONDBLCLK: // 右ダブルクリックは無視
-		return ::DefWindowProc(hWnd,msg,wParam,lParam);
+		//return ::DefWindowProc(hWnd,msg,wParam,lParam);
+		if( ignore_touch_mouse_ == false || IsTouchEvent( ::GetMessageExtraInfo() ) == false ) {
+			OnMouseDown( mbRight, GetShiftState(wParam), GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) );
+		}
+		return 0;
 
 	case WM_MBUTTONDOWN:
 		OnMouseDown( mbMiddle, GetShiftState(wParam), GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) );

--- a/environ/win32/TVPWindow.cpp
+++ b/environ/win32/TVPWindow.cpp
@@ -113,7 +113,6 @@ LRESULT WINAPI tTVPWindow::Proc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
 		OnMouseUp( mbRight, GetShiftState(wParam), GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) );
 		return 0;
 	case WM_RBUTTONDBLCLK: // 右ダブルクリックは無視
-		//return ::DefWindowProc(hWnd,msg,wParam,lParam);
 		if( ignore_touch_mouse_ == false || IsTouchEvent( ::GetMessageExtraInfo() ) == false ) {
 			OnMouseDown( mbRight, GetShiftState(wParam), GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) );
 		}


### PR DESCRIPTION
When clicking fast with the right mouse button (below system wide double click timer interval), the window will receive the WM_RBUTTONDBLCLK message instead of WM_RBUTTONDOWN. Unfortunately, this message is not handled my krkrz.
The proposed fix calls on OnMouseDown() when receiving WM_RBUTTONDOWN.