### PR TITLE
Implemented Game Controller Support via SDL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "external/jxrlib"]
 	path = external/jxrlib
 	url = https://github.com/krkrz/jxrlib.git
+[submodule "external/sdl"]
+	path = external/sdl
+	url = https://github.com/libsdl-org/SDL.git

--- a/base/win32/SystemImpl.cpp
+++ b/base/win32/SystemImpl.cpp
@@ -15,6 +15,8 @@
 
 #include "GraphicsLoaderImpl.h"
 
+#include "SDLInputMgr.h"
+
 #include "SystemImpl.h"
 #include "SystemIntf.h"
 #include "SysInitIntf.h"
@@ -68,7 +70,7 @@ bool TVPGetAsyncKeyState(tjs_uint keycode, bool getcurrent)
 	if(keycode >= VK_PAD_FIRST  && keycode <= VK_PAD_LAST)
 	{
 		// JoyPad related keys are treated in DInputMgn.cpp
-		return TVPGetJoyPadAsyncState(keycode, getcurrent);
+		return SdlGetJoyPadAsyncState(keycode, getcurrent);
 	}
 
 	if(keycode == VK_LBUTTON || keycode == VK_RBUTTON)

--- a/base/win32/SystemImpl.cpp
+++ b/base/win32/SystemImpl.cpp
@@ -70,7 +70,7 @@ bool TVPGetAsyncKeyState(tjs_uint keycode, bool getcurrent)
 	if(keycode >= VK_PAD_FIRST  && keycode <= VK_PAD_LAST)
 	{
 		// JoyPad related keys are treated in DInputMgn.cpp
-		return SdlGetJoyPadAsyncState(keycode, getcurrent);
+		return TVPGetSdlGameControllerAsyncState(keycode, getcurrent);
 	}
 
 	if(keycode == VK_LBUTTON || keycode == VK_RBUTTON)

--- a/base/win32/SystemImpl.cpp
+++ b/base/win32/SystemImpl.cpp
@@ -69,8 +69,8 @@ bool TVPGetAsyncKeyState(tjs_uint keycode, bool getcurrent)
 
 	if(keycode >= VK_PAD_FIRST  && keycode <= VK_PAD_LAST)
 	{
-		// JoyPad related keys are treated in DInputMgn.cpp
-		return TVPGetSdlGameControllerAsyncState(keycode, getcurrent);
+		// JoyPad related keys are treated in SdlInputMgr.cpp
+		return TVPGetSdlGameControllerAsyncState(keycode);
 	}
 
 	if(keycode == VK_LBUTTON || keycode == VK_RBUTTON)

--- a/environ/win32/WindowFormUnit.cpp
+++ b/environ/win32/WindowFormUnit.cpp
@@ -1291,10 +1291,10 @@ void TTVPWindowForm::GenerateMouseEvent(bool fl, bool fr, bool fu, bool fd) {
 	}
 
 	bool shift = 0!=(GetAsyncKeyState(VK_SHIFT) & 0x8000);
-	bool left = fl || GetAsyncKeyState(VK_LEFT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADLEFT, true) || TVPGetSdlGameControllerAsyncState(VK_PADLEFT, true);
-	bool right = fr || GetAsyncKeyState(VK_RIGHT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADRIGHT, true) || TVPGetSdlGameControllerAsyncState(VK_PADRIGHT, true);
-	bool up = fu || GetAsyncKeyState(VK_UP) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADUP, true) || TVPGetSdlGameControllerAsyncState(VK_PADUP, true);
-	bool down = fd || GetAsyncKeyState(VK_DOWN) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADDOWN, true) || TVPGetSdlGameControllerAsyncState(VK_PADDOWN, true);
+	bool left = fl || GetAsyncKeyState(VK_LEFT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADLEFT, true) || TVPGetSdlGameControllerAsyncState(VK_PADLEFT);
+	bool right = fr || GetAsyncKeyState(VK_RIGHT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADRIGHT, true) || TVPGetSdlGameControllerAsyncState(VK_PADRIGHT);
+	bool up = fu || GetAsyncKeyState(VK_UP) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADUP, true) || TVPGetSdlGameControllerAsyncState(VK_PADUP);
+	bool down = fd || GetAsyncKeyState(VK_DOWN) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADDOWN, true) || TVPGetSdlGameControllerAsyncState(VK_PADDOWN);
 
 	DWORD flags = 0;
 	if(left || right || up || down) flags |= MOUSEEVENTF_MOVE;

--- a/environ/win32/WindowFormUnit.cpp
+++ b/environ/win32/WindowFormUnit.cpp
@@ -501,8 +501,8 @@ void TTVPWindowForm::TickBeat(){
 	if (SdlInputManager && TJSNativeInstance) {
 		SdlInputManager->Update();
 
-		auto it = SdlInputMgr::sInstance->mControllers.find(0);
-		if (it != SdlInputMgr::sInstance->mControllers.end())
+		auto it = tTVPSDLSdlGameControllerMgr::sInstance->mControllers.find(0);
+		if (it != tTVPSDLSdlGameControllerMgr::sInstance->mControllers.end())
 		{
 			const std::vector<WORD>& uppedkeys = it->second.GetUppedKeys();
 			const std::vector<WORD>& downedkeys = it->second.GetDownedKeys();
@@ -1291,10 +1291,10 @@ void TTVPWindowForm::GenerateMouseEvent(bool fl, bool fr, bool fu, bool fd) {
 	}
 
 	bool shift = 0!=(GetAsyncKeyState(VK_SHIFT) & 0x8000);
-	bool left = fl || GetAsyncKeyState(VK_LEFT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADLEFT, true) || SdlGetJoyPadAsyncState(VK_PADLEFT, true);
-	bool right = fr || GetAsyncKeyState(VK_RIGHT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADRIGHT, true) || SdlGetJoyPadAsyncState(VK_PADRIGHT, true);
-	bool up = fu || GetAsyncKeyState(VK_UP) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADUP, true) || SdlGetJoyPadAsyncState(VK_PADUP, true);
-	bool down = fd || GetAsyncKeyState(VK_DOWN) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADDOWN, true) || SdlGetJoyPadAsyncState(VK_PADDOWN, true);
+	bool left = fl || GetAsyncKeyState(VK_LEFT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADLEFT, true) || TVPGetSdlGameControllerAsyncState(VK_PADLEFT, true);
+	bool right = fr || GetAsyncKeyState(VK_RIGHT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADRIGHT, true) || TVPGetSdlGameControllerAsyncState(VK_PADRIGHT, true);
+	bool up = fu || GetAsyncKeyState(VK_UP) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADUP, true) || TVPGetSdlGameControllerAsyncState(VK_PADUP, true);
+	bool down = fd || GetAsyncKeyState(VK_DOWN) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADDOWN, true) || TVPGetSdlGameControllerAsyncState(VK_PADDOWN, true);
 
 	DWORD flags = 0;
 	if(left || right || up || down) flags |= MOUSEEVENTF_MOVE;
@@ -1543,7 +1543,7 @@ void TTVPWindowForm::CreateDirectInputDevice() {
 	if( !DIPadDevice ) DIPadDevice = new tTVPPadDirectInputDevice(GetHandle());
 #endif
 
-	if ( !SdlInputManager ) SdlInputManager = new SdlInputMgr(GetHandle());
+	if ( !SdlInputManager ) SdlInputManager = new tTVPSDLSdlGameControllerMgr(GetHandle());
 }
 void TTVPWindowForm::FreeDirectInputDevice() {
 	if( DIWheelDevice ) {

--- a/environ/win32/WindowFormUnit.cpp
+++ b/environ/win32/WindowFormUnit.cpp
@@ -241,6 +241,7 @@ TTVPWindowForm::TTVPWindowForm( tTVPApplication* app, tTJSNI_Window* ni, tTJSNI_
 #ifndef DISABLE_EMBEDDED_GAME_PAD
 	DIPadDevice = NULL;
 #endif
+	SdlInputManager = NULL;
 	ReloadDevice = false;
 	ReloadDeviceTick = 0;
 	
@@ -496,6 +497,33 @@ void TTVPWindowForm::TickBeat(){
 		}
 	}
 #endif
+
+	if (SdlInputManager && TJSNativeInstance) {
+		SdlInputManager->Update();
+
+		auto it = SdlInputMgr::sInstance->mControllers.find(0);
+		if (it != SdlInputMgr::sInstance->mControllers.end())
+		{
+			const std::vector<WORD>& uppedkeys = it->second.GetUppedKeys();
+			const std::vector<WORD>& downedkeys = it->second.GetDownedKeys();
+			const std::vector<WORD>& repeatkeys = it->second.GetRepeatKeys();
+			std::vector<WORD>::const_iterator i;
+			
+			// for upped pad buttons
+			for (i = uppedkeys.begin(); i != uppedkeys.end(); i++) {
+				InternalKeyUp(*i, shift);
+			}
+			// for downed pad buttons
+			for (i = downedkeys.begin(); i != downedkeys.end(); i++) {
+				InternalKeyDown(*i, shift);
+			}
+			// for repeated pad buttons
+			for (i = repeatkeys.begin(); i != repeatkeys.end(); i++) {
+				InternalKeyDown(*i, shift | TVP_SS_REPEAT);
+			}
+		}
+	}
+	//SdlInputManager
 
 	// check RecheckInputState
 	if( tickcount - LastRecheckInputStateSent > 1000 ) {
@@ -1263,10 +1291,10 @@ void TTVPWindowForm::GenerateMouseEvent(bool fl, bool fr, bool fu, bool fd) {
 	}
 
 	bool shift = 0!=(GetAsyncKeyState(VK_SHIFT) & 0x8000);
-	bool left = fl || GetAsyncKeyState(VK_LEFT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADLEFT, true);
-	bool right = fr || GetAsyncKeyState(VK_RIGHT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADRIGHT, true);
-	bool up = fu || GetAsyncKeyState(VK_UP) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADUP, true);
-	bool down = fd || GetAsyncKeyState(VK_DOWN) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADDOWN, true);
+	bool left = fl || GetAsyncKeyState(VK_LEFT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADLEFT, true) || SdlGetJoyPadAsyncState(VK_PADLEFT, true);
+	bool right = fr || GetAsyncKeyState(VK_RIGHT) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADRIGHT, true) || SdlGetJoyPadAsyncState(VK_PADRIGHT, true);
+	bool up = fu || GetAsyncKeyState(VK_UP) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADUP, true) || SdlGetJoyPadAsyncState(VK_PADUP, true);
+	bool down = fd || GetAsyncKeyState(VK_DOWN) & 0x8000 || TVPGetJoyPadAsyncState(VK_PADDOWN, true) || SdlGetJoyPadAsyncState(VK_PADDOWN, true);
 
 	DWORD flags = 0;
 	if(left || right || up || down) flags |= MOUSEEVENTF_MOVE;
@@ -1514,6 +1542,8 @@ void TTVPWindowForm::CreateDirectInputDevice() {
 #ifndef DISABLE_EMBEDDED_GAME_PAD
 	if( !DIPadDevice ) DIPadDevice = new tTVPPadDirectInputDevice(GetHandle());
 #endif
+
+	if ( !SdlInputManager ) SdlInputManager = new SdlInputMgr(GetHandle());
 }
 void TTVPWindowForm::FreeDirectInputDevice() {
 	if( DIWheelDevice ) {
@@ -1526,6 +1556,10 @@ void TTVPWindowForm::FreeDirectInputDevice() {
 		DIPadDevice = NULL;
 	}
 #endif
+	if (SdlInputManager) {
+		delete SdlInputManager;
+		SdlInputManager = NULL;
+	}
 }
 
 void TTVPWindowForm::OnKeyDown( WORD vk, int shift, int repeat, bool prevkeystate ) {

--- a/environ/win32/WindowFormUnit.h
+++ b/environ/win32/WindowFormUnit.h
@@ -110,7 +110,7 @@ private:
 #ifndef DISABLE_EMBEDDED_GAME_PAD
 	tTVPPadDirectInputDevice *DIPadDevice;
 #endif
-	SdlInputMgr* SdlInputManager;
+	tTVPSDLSdlGameControllerMgr* SdlInputManager;
 	
 
 	bool ReloadDevice;

--- a/environ/win32/WindowFormUnit.h
+++ b/environ/win32/WindowFormUnit.h
@@ -6,6 +6,7 @@
 #include "tvpinputdefs.h"
 #include "WindowIntf.h"
 
+#include "SDLInputMgr.h"
 #include "TVPWindow.h"
 #include "MouseCursor.h"
 #include "TouchPoint.h"
@@ -109,6 +110,9 @@ private:
 #ifndef DISABLE_EMBEDDED_GAME_PAD
 	tTVPPadDirectInputDevice *DIPadDevice;
 #endif
+	SdlInputMgr* SdlInputManager;
+	
+
 	bool ReloadDevice;
 	DWORD ReloadDeviceTick;
 

--- a/vcproj/tvpwin32.sln
+++ b/vcproj/tvpwin32.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
@@ -11,6 +11,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tvpwin32", "tvpwin32.vcxpro
 		{01EE84B8-057A-3435-8FE2-AB4A2FB93841} = {01EE84B8-057A-3435-8FE2-AB4A2FB93841}
 		{6030C310-D5E7-39A0-A65F-6344447A66CC} = {6030C310-D5E7-39A0-A65F-6344447A66CC}
 		{E8A3F6FA-AE1C-4C8E-A0B6-9C8480324EAA} = {E8A3F6FA-AE1C-4C8E-A0B6-9C8480324EAA}
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68} = {81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zlib", "..\external\zlib\zlib.vcxproj", "{70F4D261-0235-4052-B1CF-5BE29660A43E}"
@@ -27,6 +28,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "freetype", "..\external\freetype\builds\windows\vc2012\freetype.vcxproj", "{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BaseClasses", "..\external\baseclasses\BaseClasses.vcxproj", "{E8A3F6FA-AE1C-4C8E-A0B6-9C8480324EAA}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL2", "..\external\sdl\VisualC\SDL\SDL.vcxproj", "{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -222,8 +225,39 @@ Global
 		{E8A3F6FA-AE1C-4C8E-A0B6-9C8480324EAA}.Release|Win32.Build.0 = Release|Win32
 		{E8A3F6FA-AE1C-4C8E-A0B6-9C8480324EAA}.Release|x64.ActiveCfg = Release|x64
 		{E8A3F6FA-AE1C-4C8E-A0B6-9C8480324EAA}.Release|x64.Build.0 = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Multithreaded|Win32.ActiveCfg = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Multithreaded|Win32.Build.0 = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Multithreaded|x64.ActiveCfg = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Multithreaded|x64.Build.0 = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Singlethreaded|Win32.ActiveCfg = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Singlethreaded|Win32.Build.0 = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Singlethreaded|x64.ActiveCfg = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Singlethreaded|x64.Build.0 = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|Win32.ActiveCfg = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|Win32.Build.0 = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x64.ActiveCfg = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x64.Build.0 = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Enable Debugger|Win32.ActiveCfg = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Enable Debugger|Win32.Build.0 = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Enable Debugger|x64.ActiveCfg = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Enable Debugger|x64.Build.0 = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Multithreaded|Win32.ActiveCfg = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Multithreaded|Win32.Build.0 = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Multithreaded|x64.ActiveCfg = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Multithreaded|x64.Build.0 = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Singlethreaded|Win32.ActiveCfg = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Singlethreaded|Win32.Build.0 = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Singlethreaded|x64.ActiveCfg = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Singlethreaded|x64.Build.0 = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|Win32.ActiveCfg = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|Win32.Build.0 = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.ActiveCfg = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B7684D44-D6E0-4AA8-9698-F397E859962F}
 	EndGlobalSection
 EndGlobal

--- a/vcproj/tvpwin32.vcxproj
+++ b/vcproj/tvpwin32.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -134,7 +134,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);__WIN32__;NO_STRICT;TJS_TEXT_OUT_CRLF;TJS_JP_LOCALIZED;TJS_DEBUG_DUMP_STRING;_CRT_SECURE_NO_WARNING;TVP_LOG_TO_COMMANDLINE_CONSOLE;TVP_REPORT_HW_EXCEPTION;TVP_ENABLE_EXECUTE_AT_EXCEPTION;</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;../external/sdl/include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <ExceptionHandling>Async</ExceptionHandling>
@@ -143,8 +143,8 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)lib\$(Platform)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;dsound.lib;version.lib;mpr.lib;shlwapi.lib;vfw32.lib;imm32.lib;zlib_d.lib;libpng_d.lib;onig_s_d.lib;freetype_d.lib;turbojpeg-static_d.lib;strmbasd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\$(Platform)\;$(SolutionDir)\Win32\Debug\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;dsound.lib;version.lib;mpr.lib;shlwapi.lib;vfw32.lib;imm32.lib;zlib_d.lib;libpng_d.lib;onig_s_d.lib;freetype_d.lib;turbojpeg-static_d.lib;strmbasd.lib;SDL2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <Manifest>
@@ -159,7 +159,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);__WIN32__;NO_STRICT;TJS_TEXT_OUT_CRLF;TJS_JP_LOCALIZED;TJS_DEBUG_DUMP_STRING;_CRT_SECURE_NO_WARNING;TVP_LOG_TO_COMMANDLINE_CONSOLE;TVP_REPORT_HW_EXCEPTION;TVP_ENABLE_EXECUTE_AT_EXCEPTION;</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;../external/sdl/include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <ExceptionHandling>Async</ExceptionHandling>
@@ -168,8 +168,8 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)lib\$(Platform)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;dsound.lib;version.lib;mpr.lib;shlwapi.lib;vfw32.lib;imm32.lib;zlib_d.lib;libpng_d.lib;onig_s_d.lib;freetype_d.lib;turbojpeg-static_d.lib;strmbasd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\$(Platform)\;$(SolutionDir)\x64\Debug\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;dsound.lib;version.lib;mpr.lib;shlwapi.lib;vfw32.lib;imm32.lib;zlib_d.lib;libpng_d.lib;onig_s_d.lib;freetype_d.lib;turbojpeg-static_d.lib;strmbasd.lib;SDL2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <Manifest>
@@ -186,7 +186,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);__WIN32__;NO_STRICT;TJS_TEXT_OUT_CRLF;TJS_JP_LOCALIZED;TJS_DEBUG_DUMP_STRING;TVP_LOG_TO_COMMANDLINE_CONSOLE;DISABLE_EMBEDDED_GAME_PAD;TVP_REPORT_HW_EXCEPTION;TVP_ENABLE_EXECUTE_AT_EXCEPTION;</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;../external/sdl/include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -198,8 +198,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(SolutionDir)lib\$(Platform)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;dsound.lib;version.lib;mpr.lib;shlwapi.lib;vfw32.lib;imm32.lib;zlib.lib;libpng.lib;onig_s.lib;freetype.lib;turbojpeg-static.lib;strmbase.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\$(Platform)\;$(SolutionDir)\Win32\Release\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;dsound.lib;version.lib;mpr.lib;shlwapi.lib;vfw32.lib;imm32.lib;zlib.lib;libpng.lib;onig_s.lib;freetype.lib;turbojpeg-static.lib;strmbase.lib;SDL2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
       <GenerateMapFile>true</GenerateMapFile>
       <MapFileName>$(ProjectName).map</MapFileName>
@@ -227,7 +227,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);__WIN32__;NO_STRICT;TJS_TEXT_OUT_CRLF;TJS_JP_LOCALIZED;TJS_DEBUG_DUMP_STRING;TVP_LOG_TO_COMMANDLINE_CONSOLE;DISABLE_EMBEDDED_GAME_PAD;TVP_REPORT_HW_EXCEPTION;TVP_ENABLE_EXECUTE_AT_EXCEPTION;</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;../external/sdl/include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -239,8 +239,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(SolutionDir)lib\$(Platform)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;dsound.lib;version.lib;mpr.lib;shlwapi.lib;vfw32.lib;imm32.lib;zlib.lib;libpng.lib;onig_s.lib;freetype.lib;turbojpeg-static.lib;strmbase.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\$(Platform)\;$(SolutionDir)\x64\Release\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;dsound.lib;version.lib;mpr.lib;shlwapi.lib;vfw32.lib;imm32.lib;zlib.lib;libpng.lib;onig_s.lib;freetype.lib;turbojpeg-static.lib;strmbase.lib;SDL2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <GenerateMapFile>true</GenerateMapFile>
       <MapFileName>$(ProjectName).map</MapFileName>
@@ -267,7 +267,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);__WIN32__;NO_STRICT;TJS_TEXT_OUT_CRLF;TJS_JP_LOCALIZED;TJS_DEBUG_DUMP_STRING;TVP_LOG_TO_COMMANDLINE_CONSOLE;DISABLE_EMBEDDED_GAME_PAD;TVP_REPORT_HW_EXCEPTION;ENABLE_DEBUGGER;</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;../external/sdl/include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -308,7 +308,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);__WIN32__;NO_STRICT;TJS_TEXT_OUT_CRLF;TJS_JP_LOCALIZED;TJS_DEBUG_DUMP_STRING;TVP_LOG_TO_COMMANDLINE_CONSOLE;DISABLE_EMBEDDED_GAME_PAD;TVP_REPORT_HW_EXCEPTION;ENABLE_DEBUGGER;</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../external/baseclasses;../movie/win32;../visual/gl;../extension;../tjs2;../base;../base/win32;../;../msg;../msg/win32;../sound;../sound/win32;../utils;../utils/win32;../visual;../visual/win32;../environ/win32;../visual/IA32;./;../platform/win32;../external;../external/zlib;../external/lpng;../external/libjpeg-turbo;../external/libjpeg-turbo/vcproj;../external/onig/src;../external/freetype/include;../external/jxrlib/jxrgluelib;../external/jxrlib/image/sys;../external/sdl/include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -538,6 +538,7 @@
     <ClInclude Include="..\visual\win32\krmovie.h" />
     <ClInclude Include="..\visual\win32\LayerImpl.h" />
     <ClInclude Include="..\visual\win32\NativeFreeTypeFace.h" />
+    <ClInclude Include="..\visual\win32\SDLInputMgr.h" />
     <ClInclude Include="..\visual\win32\TVPColor.h" />
     <ClInclude Include="..\visual\win32\TVPScreen.h" />
     <ClInclude Include="..\visual\win32\TVPSysFont.h" />
@@ -754,6 +755,7 @@
     <ClCompile Include="..\visual\win32\GraphicsLoaderImpl.cpp" />
     <ClCompile Include="..\visual\win32\LayerImpl.cpp" />
     <ClCompile Include="..\visual\win32\NativeFreeTypeFace.cpp" />
+    <ClCompile Include="..\visual\win32\SDLInputMgr.cpp" />
     <ClCompile Include="..\visual\win32\TVPScreen.cpp" />
     <ClCompile Include="..\visual\win32\TVPSysFont.cpp" />
     <ClCompile Include="..\visual\win32\VideoOvlImpl.cpp" />

--- a/vcproj/tvpwin32.vcxproj.filters
+++ b/vcproj/tvpwin32.vcxproj.filters
@@ -680,6 +680,9 @@
     <ClInclude Include="..\visual\gl\blend_functor_avx2.h">
       <Filter>visual\gl</Filter>
     </ClInclude>
+    <ClInclude Include="..\visual\win32\SDLInputMgr.h">
+      <Filter>visual\win32</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\tjs2\tjs.cpp">
@@ -1251,6 +1254,9 @@
     </ClCompile>
     <ClCompile Include="..\visual\gl\blend_function_avx2.cpp">
       <Filter>visual\gl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\visual\win32\SDLInputMgr.cpp">
+      <Filter>visual\win32</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/visual/win32/SDLInputMgr.cpp
+++ b/visual/win32/SDLInputMgr.cpp
@@ -1,0 +1,320 @@
+#include "SDL.h"
+
+#include "tjsCommHead.h"
+#include "SysInitIntf.h"
+
+#include "SDLInputMgr.h"
+
+
+#include "tvpinputdefs.h"
+
+//---------------------------------------------------------------------------
+WORD ConvertToTjsPad(size_t button)
+{
+    switch (button)
+    {
+        case SDL_CONTROLLER_BUTTON_A: return VK_PAD1;
+        case SDL_CONTROLLER_BUTTON_B: return VK_PAD2;
+        case SDL_CONTROLLER_BUTTON_X: return VK_PAD3;
+        case SDL_CONTROLLER_BUTTON_Y: return VK_PAD4;
+        case SDL_CONTROLLER_BUTTON_BACK: return VK_PAD7;
+        case SDL_CONTROLLER_BUTTON_START: return VK_PAD8;
+        case SDL_CONTROLLER_BUTTON_GUIDE: return VK_PAD8;
+        case SDL_CONTROLLER_BUTTON_LEFTSTICK: return VK_PAD9;
+        case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return VK_PAD10;
+        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return VK_PAD5;
+        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return  VK_PAD6;
+        case SDL_CONTROLLER_BUTTON_DPAD_UP: return  VK_PADUP;
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return  VK_PADDOWN;
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return  VK_PADLEFT;
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return  VK_PADRIGHT;
+    }
+
+    return VK_PAD2;
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+WORD ConvertFromTjsPad(size_t button)
+{
+    switch (button)
+    {
+        case VK_PAD1: return SDL_CONTROLLER_BUTTON_A;
+        case VK_PAD2: return SDL_CONTROLLER_BUTTON_B;
+        case VK_PAD3: return SDL_CONTROLLER_BUTTON_X;
+        case VK_PAD4: return SDL_CONTROLLER_BUTTON_Y;
+        case VK_PAD7: return SDL_CONTROLLER_BUTTON_BACK;
+        case VK_PAD8: return SDL_CONTROLLER_BUTTON_START;
+        case VK_PAD9: return SDL_CONTROLLER_BUTTON_LEFTSTICK;
+        case VK_PAD10: return SDL_CONTROLLER_BUTTON_RIGHTSTICK;
+        case VK_PAD5: return SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
+        case VK_PAD6: return  SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
+        case VK_PADUP: return  SDL_CONTROLLER_BUTTON_DPAD_UP;
+        case VK_PADDOWN: return  SDL_CONTROLLER_BUTTON_DPAD_DOWN;
+        case VK_PADLEFT: return  SDL_CONTROLLER_BUTTON_DPAD_LEFT;
+        case VK_PADRIGHT: return  SDL_CONTROLLER_BUTTON_DPAD_RIGHT;
+    }
+
+    return SDL_CONTROLLER_BUTTON_B;
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+Controller::Controller(SDL_GameController* aGameController)
+    : mGameController{ aGameController }
+{
+    mName = SDL_GameControllerName(aGameController);
+    mPreviousButtons.fill(false);
+    mCurrentButtons.fill(false);
+
+    //LeftStick = glm::vec2{ 0.f,0.f };
+    //RightStick = glm::vec2{ 0.f,0.f };
+    LeftTrigger = 0.f;
+    RightTrigger = 0.f;
+    Reset();
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+void Controller::Reset()
+{
+    mPreviousButtons = mCurrentButtons;
+    UppedKeys.clear();
+    RepeatKeys.clear();
+    DownedKeys.clear();
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+float Controller::ToFloat(Sint16 aValue)
+{
+    return (static_cast<float>(aValue + 32768.f) / 65535.f);
+}
+//---------------------------------------------------------------------------
+
+
+//---------------------------------------------------------------------------
+void Controller::HandleMotion(SDL_ControllerAxisEvent& aEvent)
+{
+    switch (aEvent.axis)
+    {
+        case SDL_CONTROLLER_AXIS_TRIGGERLEFT: LeftTrigger = 2.f * (ToFloat(aEvent.value) - .5f); return;
+        case SDL_CONTROLLER_AXIS_TRIGGERRIGHT: RightTrigger = 2.f * (ToFloat(aEvent.value) - .5f); return;
+    }
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+void Controller::HandleButton(SDL_ControllerButtonEvent& aEvent)
+{
+    auto buttonIndex = ConvertToIndex(aEvent.button);
+    mCurrentButtons[buttonIndex] = aEvent.state == SDL_PRESSED ? true : false;
+    //printf("%s %s\n", ConvertToString(aEvent.button), aEvent.state == SDL_PRESSED ? "Pressed" : "Released");
+
+    if (mCurrentButtons[buttonIndex] && !mPreviousButtons[buttonIndex])
+    {
+        DownedKeys.emplace_back(ConvertToTjsPad(buttonIndex));
+        RepeatWait[buttonIndex].Time = GetTickCount64();
+    }
+    else if (!mCurrentButtons[buttonIndex] && mPreviousButtons[buttonIndex])
+    {
+        UppedKeys.emplace_back(ConvertToTjsPad(buttonIndex));
+        RepeatWait[buttonIndex].Time = 0;
+        RepeatWait[buttonIndex].Interval = false;
+    }
+}
+//---------------------------------------------------------------------------
+
+
+SdlInputMgr* SdlInputMgr::sInstance = NULL;
+//---------------------------------------------------------------------------
+SdlInputMgr::SdlInputMgr(HWND handle)
+{
+	SDL_Init(SDL_INIT_GAMECONTROLLER);
+    sInstance = this;
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+SdlInputMgr::~SdlInputMgr()
+{
+	SDL_Quit();
+    sInstance = NULL;
+}
+//---------------------------------------------------------------------------
+void SdlInputMgr::UpdateKeyRepeatTimes()
+{
+    static tjs_int ArgumentGeneration = 0;
+    if (ArgumentGeneration != TVPGetCommandLineArgumentGeneration())
+    {
+        ArgumentGeneration = TVPGetCommandLineArgumentGeneration();
+        tTJSVariant val;
+        if (TVPGetCommandLine(TJS_W("-paddelay"), &val))
+        {
+            HoldTime = (int)val;
+        }
+        if (TVPGetCommandLine(TJS_W("-padinterval"), &val))
+        {
+            IntervalTime = (int)val;
+        }
+    }
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+void SdlInputMgr::Update()
+{
+	SDL_Event event;
+
+    for (auto& controller : mControllers)
+    {
+        controller.second.Reset();
+    }
+	
+	while (SDL_PollEvent(&event))
+	{
+        switch (event.type)
+        {
+                // Joypad Events
+            case SDL_CONTROLLERDEVICEADDED:
+            {
+                auto deviceEvent = event.cdevice;
+
+                auto pad = SDL_GameControllerOpen(deviceEvent.which);
+
+                if (pad)
+                {
+                    auto name = SDL_GameControllerName(pad);
+                    SDL_Joystick* joystick = SDL_GameControllerGetJoystick(pad);
+                    SDL_JoystickID instanceId = SDL_JoystickInstanceID(joystick);
+
+                    printf("Added %s, %d\n", name, instanceId);
+                    mControllers.emplace(instanceId, Controller(pad));
+                }
+                break;
+            }
+            case SDL_CONTROLLERDEVICEREMOVED:
+            {
+                auto deviceEvent = event.cdevice;
+                auto it = mControllers.find(deviceEvent.which);
+                if (it != mControllers.end())
+                {
+                  mControllers.erase(it);
+                }
+
+                printf("Removed %d\n", deviceEvent.which);
+                break;
+            }
+            // Controller Events
+            case SDL_CONTROLLERAXISMOTION:
+            {
+                mControllers[event.caxis.which].HandleMotion(event.caxis);
+                break;
+            }
+            case SDL_CONTROLLERBUTTONDOWN:
+            case SDL_CONTROLLERBUTTONUP:
+            {
+                mControllers[event.cbutton.which].HandleButton(event.cbutton);
+                break;
+            }
+            case SDL_CONTROLLERDEVICEREMAPPED:
+            {
+                puts("Remaped\n");
+                break;
+            }
+        }
+	}
+
+    auto now = GetTickCount64();
+
+    for (auto& controllerAndKey : mControllers)
+    {
+        auto& controller = controllerAndKey.second;
+        for (auto i = 0; i < controller.mCurrentButtons.size(); ++i)
+        {
+            if (controller.mCurrentButtons[i] && controller.mPreviousButtons[i])
+            {
+                auto const waitTime = controller.RepeatWait[i].Interval ? IntervalTime : HoldTime;
+                if ((now - controller.RepeatWait[i].Time) > waitTime)
+                {
+                    controller.RepeatKeys.emplace_back(ConvertToTjsPad(i));
+                    controller.RepeatWait[i].Interval = true;
+                }
+            }
+        }
+    }
+
+}
+
+//---------------------------------------------------------------------------
+// Utility functionss
+//---------------------------------------------------------------------------
+bool SdlGetJoyPadAsyncState(tjs_uint keycode, bool getcurrent)
+{
+    auto code = ConvertFromTjsPad(keycode);
+    
+    if (SdlInputMgr::sInstance)
+    {
+        auto it = SdlInputMgr::sInstance->mControllers.find(0);
+        if (it != SdlInputMgr::sInstance->mControllers.end())
+        {
+            return it->second.mCurrentButtons[code];
+        }
+        return false;
+    }
+
+	return false;
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+const char* ConvertToString(Uint8 aButton)
+{
+    switch (aButton)
+    {
+        case SDL_CONTROLLER_BUTTON_A: return "SDL_CONTROLLER_BUTTON_A";
+        case SDL_CONTROLLER_BUTTON_B: return "SDL_CONTROLLER_BUTTON_B";
+        case SDL_CONTROLLER_BUTTON_X: return "SDL_CONTROLLER_BUTTON_X";
+        case SDL_CONTROLLER_BUTTON_Y: return "SDL_CONTROLLER_BUTTON_Y";
+        case SDL_CONTROLLER_BUTTON_BACK: return "SDL_CONTROLLER_BUTTON_BACK";
+        case SDL_CONTROLLER_BUTTON_GUIDE: return "SDL_CONTROLLER_BUTTON_GUIDE";
+        case SDL_CONTROLLER_BUTTON_START: return "SDL_CONTROLLER_BUTTON_START";
+        case SDL_CONTROLLER_BUTTON_LEFTSTICK: return "SDL_CONTROLLER_BUTTON_LEFTSTICK";
+        case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return "SDL_CONTROLLER_BUTTON_RIGHTSTICK";
+        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return "SDL_CONTROLLER_BUTTON_LEFTSHOULDER";
+        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return  "SDL_CONTROLLER_BUTTON_RIGHTSHOULDER";
+        case SDL_CONTROLLER_BUTTON_DPAD_UP: return  "SDL_CONTROLLER_BUTTON_DPAD_UP";
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return  "SDL_CONTROLLER_BUTTON_DPAD_DOWN";
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return  "SDL_CONTROLLER_BUTTON_DPAD_LEFT";
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return  "SDL_CONTROLLER_BUTTON_DPAD_RIGHT";
+    }
+
+    return "ERROR";
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+size_t ConvertToIndex(Uint8 aButton)
+{
+    switch (aButton)
+    {
+        case SDL_CONTROLLER_BUTTON_A: return 0;
+        case SDL_CONTROLLER_BUTTON_B: return 1;
+        case SDL_CONTROLLER_BUTTON_X: return 2;
+        case SDL_CONTROLLER_BUTTON_Y: return 3;
+        case SDL_CONTROLLER_BUTTON_BACK: return 4;
+        case SDL_CONTROLLER_BUTTON_GUIDE: return 5;
+        case SDL_CONTROLLER_BUTTON_START: return 6;
+        case SDL_CONTROLLER_BUTTON_LEFTSTICK: return 7;
+        case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return 8;
+        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return 9;
+        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return 10;
+        case SDL_CONTROLLER_BUTTON_DPAD_UP: return 11;
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return 12;
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return 13;
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return 14;
+    }
+
+    return static_cast<size_t>(-1);
+}
+//---------------------------------------------------------------------------

--- a/visual/win32/SDLInputMgr.h
+++ b/visual/win32/SDLInputMgr.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <array>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <Windows.h>
+
+#include "tjsTypes.h"
+
+#include "SDL.h"
+
+const char* ConvertToString(Uint8 aButton);
+size_t ConvertToIndex(Uint8 aButton);
+
+class Controller
+{
+public:
+    Controller()
+    {
+        __debugbreak();
+    }
+
+    Controller(SDL_GameController* aGameController);
+
+    void Reset();
+    float ToFloat(Sint16 aValue);
+    void HandleMotion(SDL_ControllerAxisEvent& aEvent);
+    void HandleButton(SDL_ControllerButtonEvent& aEvent);
+
+    SDL_GameController* mGameController;
+    const char* mName;
+
+    std::array<bool, 15> mPreviousButtons;
+    std::array<bool, 15> mCurrentButtons;
+
+    struct RepeatInfo
+    {
+        ULONGLONG Time = 0; // When the key was pressed/last repeated
+        bool Interval = false; // Is this a subsequent repeat?
+    };
+    std::array<RepeatInfo, 15> RepeatWait;
+
+    float LeftTrigger;
+    float RightTrigger;
+
+    const std::vector<WORD>& GetUppedKeys() const { return UppedKeys; }
+    const std::vector<WORD>& GetDownedKeys() const { return DownedKeys; }
+    const std::vector<WORD>& GetRepeatKeys() const { return RepeatKeys; }
+
+    std::vector<WORD> UppedKeys;
+    std::vector<WORD> DownedKeys;
+    std::vector<WORD> RepeatKeys;
+};
+
+class SdlInputMgr
+{
+public:
+	SdlInputMgr(HWND handle);
+	~SdlInputMgr();
+
+	void Update();
+    static SdlInputMgr* sInstance;
+    std::map<SDL_JoystickID, Controller> mControllers;
+private:
+    void UpdateKeyRepeatTimes();
+
+    INT32 HoldTime = 500; // keyboard key-repeats hold-time
+    INT32 IntervalTime = 30; // keyboard key-repeats interval-time
+};
+
+bool SdlGetJoyPadAsyncState(tjs_uint keycode, bool getcurrent);

--- a/visual/win32/SDLInputMgr.h
+++ b/visual/win32/SDLInputMgr.h
@@ -1,3 +1,14 @@
+//---------------------------------------------------------------------------
+/*
+    TVP2 ( T Visual Presenter 2 )  A script authoring tool
+    Copyright (C) 2000 W.Dee <dee@kikyou.info> and contributors
+
+    See details of license at "license.txt"
+*/
+//---------------------------------------------------------------------------
+// SDL_GameController management
+//---------------------------------------------------------------------------
+
 #pragma once
 
 #include <array>
@@ -14,15 +25,18 @@
 const char* ConvertToString(Uint8 aButton);
 size_t ConvertToIndex(Uint8 aButton);
 
-class Controller
+//---------------------------------------------------------------------------
+// tTVPSDLGameController : A class for managing individuaal SDL_GameControllers.
+//---------------------------------------------------------------------------
+class tTVPSDLGameController
 {
 public:
-    Controller()
+    tTVPSDLGameController()
     {
         __debugbreak();
     }
 
-    Controller(SDL_GameController* aGameController);
+    tTVPSDLGameController(SDL_GameController* aGameController);
 
     void Reset();
     float ToFloat(Sint16 aValue);
@@ -54,20 +68,28 @@ public:
     std::vector<WORD> RepeatKeys;
 };
 
-class SdlInputMgr
+//---------------------------------------------------------------------------
+// tTVPSDLSdlGameControllerMgr : A class for managing all SDL_GameControllers.
+//---------------------------------------------------------------------------
+class tTVPSDLSdlGameControllerMgr
 {
 public:
-	SdlInputMgr(HWND handle);
-	~SdlInputMgr();
+    tTVPSDLSdlGameControllerMgr(HWND handle);
+	~tTVPSDLSdlGameControllerMgr();
 
 	void Update();
-    static SdlInputMgr* sInstance;
-    std::map<SDL_JoystickID, Controller> mControllers;
+    static tTVPSDLSdlGameControllerMgr* sInstance;
+    std::map<SDL_JoystickID, tTVPSDLGameController> mControllers;
 private:
     void UpdateKeyRepeatTimes();
 
     INT32 HoldTime = 500; // keyboard key-repeats hold-time
     INT32 IntervalTime = 30; // keyboard key-repeats interval-time
 };
+//---------------------------------------------------------------------------
 
-bool SdlGetJoyPadAsyncState(tjs_uint keycode, bool getcurrent);
+//---------------------------------------------------------------------------
+// Utility functionss
+//---------------------------------------------------------------------------
+bool TVPGetSdlGameControllerAsyncState(tjs_uint keycode, bool getcurrent);
+//---------------------------------------------------------------------------

--- a/visual/win32/SDLInputMgr.h
+++ b/visual/win32/SDLInputMgr.h
@@ -22,9 +22,6 @@
 
 #include "SDL.h"
 
-const char* ConvertToString(Uint8 aButton);
-size_t ConvertToIndex(Uint8 aButton);
-
 //---------------------------------------------------------------------------
 // tTVPSDLGameController : A class for managing individuaal SDL_GameControllers.
 //---------------------------------------------------------------------------
@@ -91,5 +88,5 @@ private:
 //---------------------------------------------------------------------------
 // Utility functionss
 //---------------------------------------------------------------------------
-bool TVPGetSdlGameControllerAsyncState(tjs_uint keycode, bool getcurrent);
+bool TVPGetSdlGameControllerAsyncState(tjs_uint keycode);
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Hi there, I know it's somewhat unlikely to be accepted, but given that the only game controller support built in uses DInput means that without some sort of third part tool, most controllers these days won't easily work. A project I use utilizes a slightly forked krkrz master branch, and I'd like to easily use a controller, hence I spent some time implementing support using SDL.

I haven't wholly replaced DInput here, but SDL is now exposed to script instead of it. But for all internal checks of the gamepad state we check both the first controller SDL gives us, as well as the existing DInput system.

Further enhancements might include having a "last active gamepad" check. Since right now we only look at the first gamepad, and this could get easily out of sync if someone were to connect multiple controllers, and then subsequently disconnect controller 1.  This way we listen to the last active gamepad.

Otherwise this could also be changed to check all connected controllers instead.

I know the multi-platform branch is actively being worked on, but I figured I'd offer this up in the meantime if you or other forks would like to pick it up. (And like I said, I'm happy to make adjustments.)